### PR TITLE
Add placeholder in Android native Editbox.

### DIFF
--- a/cocos/platform/android/java/src/org/cocos2dx/lib/Cocos2dxEditBox.java
+++ b/cocos/platform/android/java/src/org/cocos2dx/lib/Cocos2dxEditBox.java
@@ -382,12 +382,13 @@ public class Cocos2dxEditBox {
         mActivity.getGLSurfaceView().setStopHandleTouchAndKeyEvents(false);
     }
 
-    private void show(String defaultValue, int maxLength, boolean isMultiline, boolean confirmHold, String confirmType, String inputType) {
+    private void show(String defaultValue, int maxLength, boolean isMultiline, boolean confirmHold, String confirmType, String inputType, String placeholder) {
         mConfirmHold = confirmHold;
         mEditText.show(defaultValue, maxLength, isMultiline, confirmHold, confirmType, inputType);
         int editPaddingBottom = mEditText.getPaddingBottom();
         int editPadding = mEditText.getPaddingTop();
         mEditText.setPadding(editPadding, editPadding, editPadding, editPaddingBottom);
+        mEditText.setHint(placeholder);
         mButton.setText(mButtonTitle);
         if (TextUtils.isEmpty(mButtonTitle)) {
             mButton.setPadding(0, 0, 0, 0);
@@ -419,12 +420,12 @@ public class Cocos2dxEditBox {
      Functions invoked by CPP.
      **************************************************************************************/
 
-    private static void showNative(String defaultValue, int maxLength, boolean isMultiline, boolean confirmHold, String confirmType, String inputType) {
+    private static void showNative(String defaultValue, int maxLength, boolean isMultiline, boolean confirmHold, String confirmType, String inputType, String placeholder) {
         if (null != Cocos2dxEditBox.sThis) {
             Cocos2dxEditBox.sThis.mActivity.runOnUiThread(new Runnable() {
                 @Override
                 public void run() {
-                    Cocos2dxEditBox.sThis.show(defaultValue, maxLength, isMultiline, confirmHold, confirmType, inputType);
+                    Cocos2dxEditBox.sThis.show(defaultValue, maxLength, isMultiline, confirmHold, confirmType, inputType, placeholder);
                 }
             });
         }

--- a/cocos/scripting/js-bindings/manual/jsb_global.cpp
+++ b/cocos/scripting/js-bindings/manual/jsb_global.cpp
@@ -1131,7 +1131,10 @@ static bool JSB_showInputBox(se::State& s)
         SE_PRECONDITION2(ok && tmp.isString(), false, "defaultValue is invalid!");
         showInfo.defaultValue = tmp.toString();
 
-
+        ok = obj->getProperty("placeholder", &tmp);
+        SE_PRECONDITION2(ok && tmp.isString(), false, "placeholder is invalid!");
+        showInfo.placeholder = tmp.toString();
+        
         ok = obj->getProperty("maxLength", &tmp);
         SE_PRECONDITION2(ok && tmp.isNumber(), false, "maxLength is invalid!");
         showInfo.maxLength = tmp.toInt32();

--- a/cocos/ui/edit-box/EditBox-android.cpp
+++ b/cocos/ui/edit-box/EditBox-android.cpp
@@ -48,7 +48,8 @@ void EditBox::show(const cocos2d::EditBox::ShowInfo& showInfo)
                                     showInfo.isMultiline,
                                     showInfo.confirmHold,
                                     showInfo.confirmType,
-                                    showInfo.inputType);
+                                    showInfo.inputType,
+                                    showInfo.placeholder);
 }
 
 void EditBox::hide()

--- a/cocos/ui/edit-box/EditBox.h
+++ b/cocos/ui/edit-box/EditBox.h
@@ -36,6 +36,7 @@ public:
         std::string defaultValue = "";
         std::string confirmType = "";
         std::string inputType = "";
+        std::string placeholder = "";
         int maxLength = 0;
         int x = 0;
         int y = 0;


### PR DESCRIPTION
> 此 PR 需要和 jsb-adapter 另外一个 PR 同时合入，[点击查看](https://github.com/cocos-creator-packages/jsb-adapter/pull/344#issue-477941100)

在 Android native 弹起的 Editbox 上添加 placeholder。Android 虚拟机效果如图：

![Jietu20200903-001412](https://user-images.githubusercontent.com/7514260/92009472-23774200-ed7b-11ea-9f74-c67882931e34.jpg)
