### PR TITLE
Resolve planar shadow UBO initialized error

### DIFF
--- a/cocos/renderer/pipeline/RenderAdditiveLightQueue.cpp
+++ b/cocos/renderer/pipeline/RenderAdditiveLightQueue.cpp
@@ -371,6 +371,7 @@ void RenderAdditiveLightQueue::updateLightDescriptorSet(const Camera *camera, gf
 
                 // shadow info
                 float shadowInfos[4] = {shadowInfo->size.x, shadowInfo->size.y, (float)shadowInfo->pcfType, shadowInfo->bias};
+                memcpy(_shadowUBO.data() + UBOShadow::MAT_LIGHT_PLANE_PROJ_OFFSET, matShadowViewProj.m, sizeof(matShadowViewProj));
                 memcpy(_shadowUBO.data() + UBOShadow::MAT_LIGHT_VIEW_PROJ_OFFSET, matShadowViewProj.m, sizeof(matShadowViewProj));
                 memcpy(_shadowUBO.data() + UBOShadow::SHADOW_COLOR_OFFSET, &shadowInfo->color, sizeof(Vec4));
                 memcpy(_shadowUBO.data() + UBOShadow::SHADOW_INFO_OFFSET, &shadowInfos, sizeof(shadowInfos));

--- a/cocos/renderer/pipeline/ShadowMapBatchedQueue.cpp
+++ b/cocos/renderer/pipeline/ShadowMapBatchedQueue.cpp
@@ -179,6 +179,7 @@ void ShadowMapBatchedQueue::updateUBOs(const Light *light, gfx::CommandBuffer *c
             Mat4::createOrthographicOffCenter(-x, x, -y, y, shadowInfo->nearValue, farClamp, device->getClipSpaceMinZ(), projectionSinY, &matShadowViewProj);
 
             matShadowViewProj.multiply(matShadowView);
+            memcpy(shadowUBO.data() + UBOShadow::MAT_LIGHT_PLANE_PROJ_OFFSET, matShadowViewProj.m, sizeof(matShadowViewProj));
             memcpy(shadowUBO.data() + UBOShadow::MAT_LIGHT_VIEW_PROJ_OFFSET, matShadowViewProj.m, sizeof(matShadowViewProj));
         } break;
         case LightType::SPOT: {
@@ -190,6 +191,7 @@ void ShadowMapBatchedQueue::updateUBOs(const Light *light, gfx::CommandBuffer *c
             cc::Mat4::createPerspective(light->spotAngle, light->aspect, 0.001f, light->range, &matShadowViewProj);
 
             matShadowViewProj.multiply(matShadowView);
+            memcpy(shadowUBO.data() + UBOShadow::MAT_LIGHT_PLANE_PROJ_OFFSET, matShadowViewProj.m, sizeof(matShadowViewProj));
             memcpy(shadowUBO.data() + UBOShadow::MAT_LIGHT_VIEW_PROJ_OFFSET, matShadowViewProj.m, sizeof(matShadowViewProj));
         } break;
         default: break;

--- a/cocos/renderer/pipeline/forward/ForwardPipeline.cpp
+++ b/cocos/renderer/pipeline/forward/ForwardPipeline.cpp
@@ -291,13 +291,14 @@ void ForwardPipeline::updateShadowUBO(Camera *camera) {
 
             matShadowViewProj.multiply(matShadowView);
             float shadowInfos[4] = {shadowInfo->size.x, shadowInfo->size.y, (float)shadowInfo->pcfType, shadowInfo->bias};
+            memcpy(_shadowUBO.data() + UBOShadow::MAT_LIGHT_PLANE_PROJ_OFFSET, matShadowViewProj.m, sizeof(matShadowViewProj));
             memcpy(_shadowUBO.data() + UBOShadow::MAT_LIGHT_VIEW_PROJ_OFFSET, matShadowViewProj.m, sizeof(matShadowViewProj));
+            memcpy(_shadowUBO.data() + UBOShadow::SHADOW_COLOR_OFFSET, &shadowInfo->color, sizeof(Vec4));
             memcpy(_shadowUBO.data() + UBOShadow::SHADOW_INFO_OFFSET, &shadowInfos, sizeof(shadowInfos));
         } else if (mainLight && shadowInfo->getShadowType() == ShadowType::PLANAR) {
             updateDirLight(shadowInfo, mainLight, _shadowUBO);
         }
 
-        memcpy(_shadowUBO.data() + UBOShadow::SHADOW_COLOR_OFFSET, &shadowInfo->color, sizeof(Vec4));
         _commandBuffers[0]->updateBuffer(_descriptorSet->getBuffer(UBOShadow::BINDING), _shadowUBO.data(), UBOShadow::SIZE);
     }
     _descriptorSet->update();

--- a/cocos/renderer/pipeline/forward/SceneCulling.cpp
+++ b/cocos/renderer/pipeline/forward/SceneCulling.cpp
@@ -133,7 +133,11 @@ void updateDirLight(Shadows *shadows, const Light *light, std::array<float, UBOS
     matLight.m[14] = lz * distance;
     matLight.m[15] = 1;
 
+    float shadowInfos[4] = {shadows->size.x, shadows->size.y, (float)shadows->pcfType, shadows->bias};
     memcpy(shadowUBO.data() + UBOShadow::MAT_LIGHT_PLANE_PROJ_OFFSET, matLight.m, sizeof(matLight));
+    memcpy(shadowUBO.data() + UBOShadow::MAT_LIGHT_VIEW_PROJ_OFFSET, matLight.m, sizeof(matLight));
+    memcpy(shadowUBO.data() + UBOShadow::SHADOW_COLOR_OFFSET, &shadows->color, sizeof(Vec4));
+    memcpy(shadowUBO.data() + UBOShadow::SHADOW_INFO_OFFSET, &shadowInfos, sizeof(shadowInfos));
 }
 
 void lightCollecting(Camera *camera, std::vector<const Light *> &validLights) {


### PR DESCRIPTION
* 在原生平台，因为很多多地方使用了 `shadowUBO.fill(0.f);` 这个方法，致使在光照pass 阶段，将 global 中关于 planarUBO 的数据清 0，且颜色数据也未填充。导致多光源下，planar 阴影消失的问题。
https://github.com/cocos-creator/3d-tasks/issues/6019