### PR TITLE
fix dragonbones resource import crash bug.

### DIFF
--- a/cocos/editor-support/dragonbones/parser/JSONDataParser.cpp
+++ b/cocos/editor-support/dragonbones/parser/JSONDataParser.cpp
@@ -1341,7 +1341,13 @@ unsigned JSONDataParser::_parseZOrderFrame(const rapidjson::Value& rawData, unsi
                 }
                 
                 unsigned index = originalIndex + zOrderOffset;
-                CCASSERT(index >= 0 && index < zOrders.size(), "DragonBones::JSONDataParser index is invalid");
+                // CCASSERT(index >= 0 && index < zOrders.size(), "DragonBones::JSONDataParser index is invalid");
+                        
+                if (!(index >= 0 && index < zOrders.size()))
+                {
+                    originalIndex++;
+                    continue;
+                }
                 zOrders[index] = originalIndex++;
             }
 
@@ -1358,7 +1364,14 @@ unsigned JSONDataParser::_parseZOrderFrame(const rapidjson::Value& rawData, unsi
             {
                 if (zOrders[i] == -1) 
                 {
-                    _frameArray[frameOffset + 2 + i] = unchanged[--unchangedIndex];
+                    // _frameArray[frameOffset + 2 + i] = unchanged[--unchangedIndex];
+                    
+                    if(unchangedIndex > 0) {
+                        _frameArray[frameOffset + 2 + i] = unchanged[--unchangedIndex];
+                    } 
+                    else {
+                        _frameArray[frameOffset + 2 + i] = 0;
+                    }
                 }
                 else {
                     _frameArray[frameOffset + 2 + i] = zOrders[i];


### PR DESCRIPTION
添加判断避免美术给资源会越界而导致崩溃
相关issue:cocos-creator/3d-tasks#6250