### PR TITLE
fix: do not draw the buffer object if glBufferData failed

### DIFF
--- a/cocos/renderer/gfx/DeviceGraphics.cpp
+++ b/cocos/renderer/gfx/DeviceGraphics.cpp
@@ -409,6 +409,15 @@ void DeviceGraphics::draw(size_t base, GLsizei count)
     }
     
     commitTextures();
+
+    if(!nextIndexBuffer->isDrawable()){
+        _drawCalls++;
+        auto temp = _nextState;
+        _nextState = _currentState;
+        _currentState = temp;
+        _nextState->reset();
+        return;
+    }
     
     //commit uniforms
     const auto& uniformsInfo = _nextState->getProgram()->getUniforms();

--- a/cocos/renderer/gfx/DeviceGraphics.cpp
+++ b/cocos/renderer/gfx/DeviceGraphics.cpp
@@ -389,6 +389,14 @@ void DeviceGraphics::draw(size_t base, GLsizei count)
     commitVertexBuffer();
     
     auto nextIndexBuffer = _nextState->getIndexBuffer();
+
+    if(!nextIndexBuffer->isDrawable()){
+        _drawCalls++;
+        std::swap(_nextState, _currentState);
+        _nextState->reset();
+        return;
+    }
+
     if (_currentState->getIndexBuffer() != nextIndexBuffer)
     {
         GL_CHECK(ccBindBuffer(GL_ELEMENT_ARRAY_BUFFER, nextIndexBuffer ? nextIndexBuffer->getHandle() : 0));
@@ -409,15 +417,6 @@ void DeviceGraphics::draw(size_t base, GLsizei count)
     }
     
     commitTextures();
-
-    if(!nextIndexBuffer->isDrawable()){
-        _drawCalls++;
-        auto temp = _nextState;
-        _nextState = _currentState;
-        _currentState = temp;
-        _nextState->reset();
-        return;
-    }
     
     //commit uniforms
     const auto& uniformsInfo = _nextState->getProgram()->getUniforms();

--- a/cocos/renderer/gfx/IndexBuffer.cpp
+++ b/cocos/renderer/gfx/IndexBuffer.cpp
@@ -50,6 +50,7 @@ bool IndexBuffer::init(DeviceGraphics* device, IndexFormat format, Usage usage, 
     _usage = usage;
     _numIndices = numIndices;
     _bytesPerIndex = 0;
+    _drawable = true;
     
     _needExpandDataStore = true;
 
@@ -111,27 +112,19 @@ void IndexBuffer::update(uint32_t offset, const void* data, size_t dataByteLengt
     {
 //        glBufferData(GL_ELEMENT_ARRAY_BUFFER, (GLsizeiptr)dataByteLength, data, glUsage);
         glBufferData(GL_ELEMENT_ARRAY_BUFFER, _bytes, (const GLvoid*)data, glUsage);
-        GLenum gl_err = glGetError();
-        if (0 != gl_err){
-            RENDERER_LOGE("GL error 0x%x: %s:%s", gl_err, glEnumName(gl_err), __FUNCTION__);
-            _drawable = false;
-        }else{
-            _drawable = true;
-        }
         _needExpandDataStore = false;
     }
     else
     {
         glBufferSubData(GL_ELEMENT_ARRAY_BUFFER, (GLintptr)offset, (GLsizeiptr)dataByteLength, (const GLvoid*)data);
-        GLenum gl_err = glGetError();
-        if (0 != gl_err){
-            RENDERER_LOGE("GL error 0x%x: %s:%s", gl_err, glEnumName(gl_err), __FUNCTION__);
-            _drawable = false;
-        }else{
-            _drawable = true;
-        }
     }
-    
+    GLenum glError = glGetError();
+    if (0 != glError){
+        RENDERER_LOGE("GL error 0x%x: %s:%s", glError, glEnumName(glError), __FUNCTION__);
+        _drawable = false;
+    }else{
+        _drawable = true;
+    }
     _device->restoreIndexBuffer();
 }
 

--- a/cocos/renderer/gfx/IndexBuffer.cpp
+++ b/cocos/renderer/gfx/IndexBuffer.cpp
@@ -22,6 +22,7 @@
  THE SOFTWARE.
  ****************************************************************************/
 
+#include "GFXUtils.h"
 #include "IndexBuffer.h"
 #include "DeviceGraphics.h"
 #include "base/CCGLUtils.h"
@@ -110,11 +111,25 @@ void IndexBuffer::update(uint32_t offset, const void* data, size_t dataByteLengt
     {
 //        glBufferData(GL_ELEMENT_ARRAY_BUFFER, (GLsizeiptr)dataByteLength, data, glUsage);
         glBufferData(GL_ELEMENT_ARRAY_BUFFER, _bytes, (const GLvoid*)data, glUsage);
+        GLenum gl_err = glGetError();
+        if (0 != gl_err){
+            RENDERER_LOGE("GL error 0x%x: %s:%s", gl_err, glEnumName(gl_err), __FUNCTION__);
+            _drawable = false;
+        }else{
+            _drawable = true;
+        }
         _needExpandDataStore = false;
     }
     else
     {
         glBufferSubData(GL_ELEMENT_ARRAY_BUFFER, (GLintptr)offset, (GLsizeiptr)dataByteLength, (const GLvoid*)data);
+        GLenum gl_err = glGetError();
+        if (0 != gl_err){
+            RENDERER_LOGE("GL error 0x%x: %s:%s", gl_err, glEnumName(gl_err), __FUNCTION__);
+            _drawable = false;
+        }else{
+            _drawable = true;
+        }
     }
     
     _device->restoreIndexBuffer();

--- a/cocos/renderer/gfx/IndexBuffer.h
+++ b/cocos/renderer/gfx/IndexBuffer.h
@@ -118,6 +118,11 @@ public:
      */
     inline uint32_t getBytes() const { return _bytes; }
 
+    /**
+     * Whether the buffer data can be drawn
+     */
+    inline bool isDrawable() const { return _drawable; }
+
     using FetchDataCallback = std::function<uint8_t*(size_t*)>;
     void setFetchDataCallback(const FetchDataCallback& cb) { _fetchDataCallback = cb; }
     uint8_t* invokeFetchDataCallback(size_t* bytes) {
@@ -142,6 +147,7 @@ private:
     uint32_t _bytesPerIndex;
     uint32_t _bytes;
     bool _needExpandDataStore = true;
+    bool _drawable = true;
 
     FetchDataCallback _fetchDataCallback;
 


### PR DESCRIPTION
If `glBufferData()` failed, it's easily to get SIGSEGV crash when calling `glDrawElements()`.

This PR add a `glGetError()` checking after calling `glBufferData()` to avoid calling `glDrawElements()` after `glBufferData()` failed.

Related discussion: https://forum.cocos.org/t/topic/104524/6