### PR TITLE
avoid default NDK download after delete :instantapp project

### DIFF
--- a/templates/android/build/libservice/build.gradle
+++ b/templates/android/build/libservice/build.gradle
@@ -2,6 +2,7 @@ apply plugin: 'com.android.library'
 
 android {
     compileSdkVersion PROP_COMPILE_SDK_VERSION.toInteger()
+    ndkPath PROP_NDK_PATH
 
     defaultConfig {
         minSdkVersion PROP_MIN_SDK_VERSION


### PR DESCRIPTION
because include a jniLibs.srcDirs setting, so need add ndkPath, or it will download the default NDK version if it not exist.