### PR TITLE
Fix render mesh issue in native engine.

### DIFF
--- a/cocos/renderer/gfx-gles2/GLES2Device.cpp
+++ b/cocos/renderer/gfx-gles2/GLES2Device.cpp
@@ -25,7 +25,6 @@ THE SOFTWARE.
 
 #include "GLES2Buffer.h"
 #include "GLES2CommandBuffer.h"
-#include "GLES2PrimaryCommandBuffer.h"
 #include "GLES2Context.h"
 #include "GLES2DescriptorSet.h"
 #include "GLES2DescriptorSetLayout.h"
@@ -35,6 +34,7 @@ THE SOFTWARE.
 #include "GLES2InputAssembler.h"
 #include "GLES2PipelineLayout.h"
 #include "GLES2PipelineState.h"
+#include "GLES2PrimaryCommandBuffer.h"
 #include "GLES2Queue.h"
 #include "GLES2RenderPass.h"
 #include "GLES2Sampler.h"
@@ -95,6 +95,7 @@ bool GLES2Device::initialize(const DeviceInfo &info) {
     _features[(int)Feature::FORMAT_R11G11B10F] = true;
     _features[(int)Feature::FORMAT_D24S8] = true;
     _features[(int)Feature::MSAA] = true;
+    _features[(uint)Feature::ELEMENT_INDEX_UINT] = GL_OES_element_index_uint;
 
     if (checkExtension("color_buffer_float"))
         _features[(int)Feature::COLOR_FLOAT] = true;
@@ -312,7 +313,7 @@ void GLES2Device::copyBuffersToTexture(const uint8_t *const *buffers, Texture *d
 bool GLES2Device::checkForETC2() const {
     GLint numFormats = 0;
     glGetIntegerv(GL_NUM_COMPRESSED_TEXTURE_FORMATS, &numFormats);
-    GLint* formats = new GLint[numFormats];
+    GLint *formats = new GLint[numFormats];
     glGetIntegerv(GL_COMPRESSED_TEXTURE_FORMATS, formats);
 
     int supportNum = 0;
@@ -320,7 +321,7 @@ bool GLES2Device::checkForETC2() const {
         if (formats[i] == GL_COMPRESSED_RGB8_ETC2 || formats[i] == GL_COMPRESSED_RGBA8_ETC2_EAC)
             supportNum++;
     }
-    delete [] formats;
+    delete[] formats;
 
     return supportNum >= 2;
 }

--- a/cocos/renderer/gfx-gles2/GLES2Device.cpp
+++ b/cocos/renderer/gfx-gles2/GLES2Device.cpp
@@ -95,7 +95,10 @@ bool GLES2Device::initialize(const DeviceInfo &info) {
     _features[(int)Feature::FORMAT_R11G11B10F] = true;
     _features[(int)Feature::FORMAT_D24S8] = true;
     _features[(int)Feature::MSAA] = true;
-    _features[(uint)Feature::ELEMENT_INDEX_UINT] = GL_OES_element_index_uint;
+
+    if (checkExtension("GL_OES_element_index_uint")) {
+        _features[(int)Feature::ELEMENT_INDEX_UINT] = true;
+    }
 
     if (checkExtension("color_buffer_float"))
         _features[(int)Feature::COLOR_FLOAT] = true;

--- a/cocos/renderer/gfx-gles3/GLES3Device.cpp
+++ b/cocos/renderer/gfx-gles3/GLES3Device.cpp
@@ -92,10 +92,7 @@ bool GLES3Device::initialize(const DeviceInfo &info) {
     _features[(int)Feature::INSTANCED_ARRAYS] = true;
     _features[(int)Feature::MULTIPLE_RENDER_TARGETS] = true;
     _features[(uint)Feature::BLEND_MINMAX] = true;
-    
-    if (checkExtension("GL_OES_element_index_uint")) {
-        _features[(int)Feature::ELEMENT_INDEX_UINT] = true;
-    }
+    _features[(int)Feature::ELEMENT_INDEX_UINT] = true;
 
     if (checkExtension("color_buffer_float"))
         _features[(int)Feature::COLOR_FLOAT] = true;

--- a/cocos/renderer/gfx-gles3/GLES3Device.cpp
+++ b/cocos/renderer/gfx-gles3/GLES3Device.cpp
@@ -92,7 +92,10 @@ bool GLES3Device::initialize(const DeviceInfo &info) {
     _features[(int)Feature::INSTANCED_ARRAYS] = true;
     _features[(int)Feature::MULTIPLE_RENDER_TARGETS] = true;
     _features[(uint)Feature::BLEND_MINMAX] = true;
-    _features[(uint)Feature::ELEMENT_INDEX_UINT] = GL_OES_element_index_uint;
+    
+    if (checkExtension("GL_OES_element_index_uint")) {
+        _features[(int)Feature::ELEMENT_INDEX_UINT] = true;
+    }
 
     if (checkExtension("color_buffer_float"))
         _features[(int)Feature::COLOR_FLOAT] = true;

--- a/cocos/renderer/gfx-gles3/GLES3Device.cpp
+++ b/cocos/renderer/gfx-gles3/GLES3Device.cpp
@@ -92,6 +92,7 @@ bool GLES3Device::initialize(const DeviceInfo &info) {
     _features[(int)Feature::INSTANCED_ARRAYS] = true;
     _features[(int)Feature::MULTIPLE_RENDER_TARGETS] = true;
     _features[(uint)Feature::BLEND_MINMAX] = true;
+    _features[(uint)Feature::ELEMENT_INDEX_UINT] = GL_OES_element_index_uint;
 
     if (checkExtension("color_buffer_float"))
         _features[(int)Feature::COLOR_FLOAT] = true;

--- a/cocos/renderer/gfx-metal/MTLCommandBuffer.h
+++ b/cocos/renderer/gfx-metal/MTLCommandBuffer.h
@@ -85,13 +85,12 @@ private:
     bool _indirectDrawSuppotred = false;
     bool _commandBufferBegan = false;
     CCMTLDevice *_mtlDevice = nullptr;
-//    id<CAMetalDrawable> _currDrawable = nil;
+    //    id<CAMetalDrawable> _currDrawable = nil;
     id<MTLCommandQueue> _mtlCommandQueue = nil;
     id<MTLCommandBuffer> _mtlCommandBuffer = nil;
     MTKView *_mtkView = nil;
     CCMTLRenderCommandEncoder _commandEncoder;
     CCMTLInputAssembler *_inputAssembler = nullptr;
-    MTLIndexType _indexType = MTLIndexTypeUInt16;
     MTLPrimitiveType _mtlPrimitiveType = MTLPrimitiveType::MTLPrimitiveTypeTriangle;
 };
 

--- a/cocos/renderer/gfx-metal/MTLCommandBuffer.mm
+++ b/cocos/renderer/gfx-metal/MTLCommandBuffer.mm
@@ -215,9 +215,8 @@ void CCMTLCommandBuffer::draw(InputAssembler *ia) {
             if (_indirectDrawSuppotred) {
                 ++_numDrawCalls;
                 if (indirectBuffer->isDrawIndirectByIndex()) {
-                    _indexType = indexBuffer->getIndexType();
                     [mtlEncoder drawIndexedPrimitives:_mtlPrimitiveType
-                                            indexType:_indexType
+                                            indexType:indexBuffer->getIndexType()
                                           indexBuffer:indexBuffer->getMTLBuffer()
                                     indexBufferOffset:0
                                        indirectBuffer:indirectMTLBuffer
@@ -238,17 +237,16 @@ void CCMTLCommandBuffer::draw(InputAssembler *ia) {
                     const auto &drawInfo = drawInfos[i];
                     offset += drawInfo.firstIndex * stride;
                     if (indirectBuffer->isDrawIndirectByIndex()) {
-                        _indexType = indexBuffer->getIndexType();
                         if (drawInfo.instanceCount == 0) {
                             [mtlEncoder drawIndexedPrimitives:_mtlPrimitiveType
                                                    indexCount:drawInfo.indexCount
-                                                    indexType:_indexType
+                                                    indexType:indexBuffer->getIndexType()
                                                   indexBuffer:indexBuffer->getMTLBuffer()
                                             indexBufferOffset:offset];
                         } else {
                             [mtlEncoder drawIndexedPrimitives:_mtlPrimitiveType
                                                    indexCount:drawInfo.indexCount
-                                                    indexType:_indexType
+                                                    indexType:indexBuffer->getIndexType()
                                                   indexBuffer:indexBuffer->getMTLBuffer()
                                             indexBufferOffset:offset
                                                 instanceCount:drawInfo.instanceCount];
@@ -271,19 +269,18 @@ void CCMTLCommandBuffer::draw(InputAssembler *ia) {
             DrawInfo drawInfo;
             static_cast<CCMTLInputAssembler *>(ia)->extractDrawInfo(drawInfo);
             if (drawInfo.indexCount > 0) {
-                _indexType = indexBuffer->getIndexType();
                 uint offset = 0;
                 offset += drawInfo.firstIndex * indexBuffer->getStride();
                 if (drawInfo.instanceCount == 0) {
                     [mtlEncoder drawIndexedPrimitives:_mtlPrimitiveType
                                            indexCount:drawInfo.indexCount
-                                            indexType:_indexType
+                                            indexType:indexBuffer->getIndexType()
                                           indexBuffer:indexBuffer->getMTLBuffer()
                                     indexBufferOffset:offset];
                 } else {
                     [mtlEncoder drawIndexedPrimitives:_mtlPrimitiveType
                                            indexCount:drawInfo.indexCount
-                                            indexType:_indexType
+                                            indexType:indexBuffer->getIndexType()
                                           indexBuffer:indexBuffer->getMTLBuffer()
                                     indexBufferOffset:offset
                                         instanceCount:drawInfo.instanceCount];

--- a/cocos/renderer/gfx-metal/MTLCommandBuffer.mm
+++ b/cocos/renderer/gfx-metal/MTLCommandBuffer.mm
@@ -208,6 +208,8 @@ void CCMTLCommandBuffer::draw(InputAssembler *ia) {
     const auto *indexBuffer = static_cast<CCMTLBuffer *>(ia->getIndexBuffer());
     auto mtlEncoder = _commandEncoder.getMTLEncoder();
 
+    _indexType = indexBuffer->getIndexType();
+
     if (_type == CommandBufferType::PRIMARY) {
         if (indirectBuffer) {
             const auto indirectMTLBuffer = indirectBuffer->getMTLBuffer();

--- a/cocos/renderer/gfx-metal/MTLCommandBuffer.mm
+++ b/cocos/renderer/gfx-metal/MTLCommandBuffer.mm
@@ -208,8 +208,6 @@ void CCMTLCommandBuffer::draw(InputAssembler *ia) {
     const auto *indexBuffer = static_cast<CCMTLBuffer *>(ia->getIndexBuffer());
     auto mtlEncoder = _commandEncoder.getMTLEncoder();
 
-    _indexType = indexBuffer->getIndexType();
-
     if (_type == CommandBufferType::PRIMARY) {
         if (indirectBuffer) {
             const auto indirectMTLBuffer = indirectBuffer->getMTLBuffer();
@@ -217,6 +215,7 @@ void CCMTLCommandBuffer::draw(InputAssembler *ia) {
             if (_indirectDrawSuppotred) {
                 ++_numDrawCalls;
                 if (indirectBuffer->isDrawIndirectByIndex()) {
+                    _indexType = indexBuffer->getIndexType();
                     [mtlEncoder drawIndexedPrimitives:_mtlPrimitiveType
                                             indexType:_indexType
                                           indexBuffer:indexBuffer->getMTLBuffer()
@@ -239,6 +238,7 @@ void CCMTLCommandBuffer::draw(InputAssembler *ia) {
                     const auto &drawInfo = drawInfos[i];
                     offset += drawInfo.firstIndex * stride;
                     if (indirectBuffer->isDrawIndirectByIndex()) {
+                        _indexType = indexBuffer->getIndexType();
                         if (drawInfo.instanceCount == 0) {
                             [mtlEncoder drawIndexedPrimitives:_mtlPrimitiveType
                                                    indexCount:drawInfo.indexCount
@@ -271,6 +271,7 @@ void CCMTLCommandBuffer::draw(InputAssembler *ia) {
             DrawInfo drawInfo;
             static_cast<CCMTLInputAssembler *>(ia)->extractDrawInfo(drawInfo);
             if (drawInfo.indexCount > 0) {
+                _indexType = indexBuffer->getIndexType();
                 uint offset = 0;
                 offset += drawInfo.firstIndex * indexBuffer->getStride();
                 if (drawInfo.instanceCount == 0) {

--- a/cocos/renderer/gfx-metal/MTLDevice.mm
+++ b/cocos/renderer/gfx-metal/MTLDevice.mm
@@ -147,6 +147,7 @@ bool CCMTLDevice::initialize(const DeviceInfo &info) {
     _features[(int)Feature::INSTANCED_ARRAYS] = true;
     _features[(int)Feature::MULTIPLE_RENDER_TARGETS] = true;
     _features[(uint)Feature::BLEND_MINMAX] = true;
+    _features[(uint)Feature::ELEMENT_INDEX_UINT] = true;
     _features[static_cast<uint>(Feature::DEPTH_BOUNDS)] = false;
     _features[static_cast<uint>(Feature::LINE_WIDTH)] = false;
     _features[static_cast<uint>(Feature::STENCIL_COMPARE_MASK)] = false;


### PR DESCRIPTION
in engine/........./mesh.ts:
```
  if (dstStride === 4 && !gfxDevice.hasFeature(Feature.ELEMENT_INDEX_UINT)) {
      const vertexCount = this._struct.vertexBundles[prim.vertexBundelIndices[0]].view.count;
      if (vertexCount >= 65536) {
          warnID(10001, vertexCount, 65536);
          console.log('prim.ignored');
          continue; // Ignore this primitive
      } else {
          dstStride >>= 1; // Reduce to short.
          dstSize >>= 1;
      }
  }
```

this one `gfxDevice.hasFeature(Feature.ELEMENT_INDEX_UINT)` matters