### PR TITLE
fix editbox multiline mode can't end editing

### DIFF
--- a/cocos/ui/edit-box/EditBox-mac.mm
+++ b/cocos/ui/edit-box/EditBox-mac.mm
@@ -74,6 +74,10 @@ se::Value g_textInputCallback;
 
     return TRUE;
 }
+
+- (void) textDidEndEditing:(NSNotification *)notification {
+    cc::EditBox::complete();
+}
 @end
 
 /*************************************************************************


### PR DESCRIPTION
resolve: https://github.com/cocos-creator/3d-tasks/issues/6522

NOTE: this pr  https://github.com/cocos-creator/engine-native/pull/3295 missed processing the text view