### PR TITLE
fix that after clicking the virtual Home button to hide the App, the Home button is not hidden after reopening the App.

### DIFF
--- a/cocos/platform/android/java/src/com/cocos/lib/CocosActivity.java
+++ b/cocos/platform/android/java/src/com/cocos/lib/CocosActivity.java
@@ -181,6 +181,7 @@ public class CocosActivity extends Activity implements SurfaceHolder.Callback {
         mSensorHandler.onResume();
         mOrientationHelper.onResume();
         onResumeNative();
+        Utils.hideVirtualButton();
     }
 
     @Override


### PR DESCRIPTION
After the restoration of virtual Home button click to hide App, App Home key to re-open not hidden.