### PR TITLE
Fix: crash when calling a function with the long type return value

### DIFF
--- a/cocos/bindings/manual/JavaScriptJavaBridge.cpp
+++ b/cocos/bindings/manual/JavaScriptJavaBridge.cpp
@@ -238,7 +238,7 @@ bool JavaScriptJavaBridge::CallInfo::executeWithArgs(jvalue *args) {
             break;
 
         case JavaScriptJavaBridge::ValueType::LONG:
-            m_ret.longValue = m_env->CallStaticIntMethodA(m_classID, m_methodID, args);
+            m_ret.longValue = m_env->CallStaticLongMethodA(m_classID, m_methodID, args);
             break;
 
         case JavaScriptJavaBridge::ValueType::FLOAT:


### PR DESCRIPTION
Platform: Android

Fix problem: crash when calling a function with args that has a return
value of long type.