### PR TITLE
fix mac warning

### DIFF
--- a/cocos/renderer/gfx-metal/MTLBuffer.mm
+++ b/cocos/renderer/gfx-metal/MTLBuffer.mm
@@ -94,6 +94,7 @@ bool CCMTLBuffer::createMTLBuffer(uint size, MemoryUsage usage) {
     if (_mtlBuffer == nil) {
         return false;
     }
+    return true;
 }
 
 void CCMTLBuffer::doDestroy() {


### PR DESCRIPTION
fix mac warning using cmd to compile instead of xcode