### PR TITLE
fix: pause/resume should modify state

### DIFF
--- a/cocos/audio/AudioEngine.cpp
+++ b/cocos/audio/AudioEngine.cpp
@@ -317,6 +317,7 @@ void AudioEngine::onEnterBackground(const CustomEvent &event) {
     for (auto it = _audioIDInfoMap.begin(); it != itEnd; ++it) {
         if (it->second.state == AudioState::PLAYING) {
             _audioEngineImpl->pause(it->first);
+            it->second.state = AudioState::PAUSED;
             _breakAudioID.push_back(it->first);
         }
     }
@@ -331,7 +332,12 @@ void AudioEngine::onEnterBackground(const CustomEvent &event) {
 void AudioEngine::onEnterForeground(const CustomEvent &event) {
     auto itEnd = _breakAudioID.end();
     for (auto it = _breakAudioID.begin(); it != itEnd; ++it) {
-        _audioEngineImpl->resume(*it);
+        auto iter = _audioIDInfoMap.find(*it);
+        if (iter != _audioIDInfoMap.end() && iter->second.state == AudioState::PAUSED)
+        {
+            _audioEngineImpl->resume(*it);
+            iter->second.state = AudioState::PLAYING;
+        }
     }
     _breakAudioID.clear();
 


### PR DESCRIPTION
问题是这样的，我们在使用cocoscreator3d v1.2版本开发ios游戏的时候，测试同学反馈iphone重复锁屏解锁n次后，出现了声音重复播放的问题。

通过排查发现：
native层的AudioEngine::onEnterForeground和AudioEngine::onEnterForeground其实有对声音做pause和play的处理，但是却没有修改声音的state。

但是js层的AudioPlayer（参考https://github.com/cocos-creator/engine/blob/develop/cocos/audio/assets/player.ts 58-70行代码）也监听了Game.EVENT_HIDE/EVENT_SHOW事件，每次锁屏/解锁都会调用到this.pause/play()，进而调用到native层的AudioEngine::pause/resume。

目前底层ios的声音resume实现应该是有问题的，重复调用resume会导致声音重复播放，这里具体逻辑我还没仔细看。

但是能确定的是，如果AudioEngine::onEnterForeground/AudioEngine::onEnterForeground能处理下声音的state，后续js层监听Game.EVENT_HIDE/EVENT_SHOW后调用AudioEngine::pause/resume的时候，检测到state不满足就不会重复调用resume，可以规避这个问题。


