### PR TITLE
fix simulator compiling on Win32

### DIFF
--- a/tools/simulator/frameworks/runtime-src/Classes/ide-support/RuntimeJsImpl.cpp
+++ b/tools/simulator/frameworks/runtime-src/Classes/ide-support/RuntimeJsImpl.cpp
@@ -30,6 +30,7 @@
 //
 
 // NOTE: fix the conflict typedef 'byte' between C++17 and one Windows header named 'rpcndr.h'
+// reference: https://studiofreya.com/2018/01/06/visual-studio-2017-with-cpp17-and-boost/#stdbyte-ambiguous-symbol-and-rpcndr.h
 #ifdef WIN32
 #define _HAS_STD_BYTE 0
 #endif

--- a/tools/simulator/frameworks/runtime-src/Classes/ide-support/RuntimeJsImpl.cpp
+++ b/tools/simulator/frameworks/runtime-src/Classes/ide-support/RuntimeJsImpl.cpp
@@ -29,7 +29,7 @@
 //
 //
 
-// NOTE: fix the conflict typedef between C++17 and one Windows header named 'rpcndr.h'
+// NOTE: fix the conflict typedef 'byte' between C++17 and one Windows header named 'rpcndr.h'
 #ifdef WIN32
 #define _HAS_STD_BYTE 0
 #endif

--- a/tools/simulator/frameworks/runtime-src/Classes/ide-support/RuntimeJsImpl.cpp
+++ b/tools/simulator/frameworks/runtime-src/Classes/ide-support/RuntimeJsImpl.cpp
@@ -29,6 +29,10 @@
 //
 //
 
+#ifdef WIN32
+#define _HAS_STD_BYTE 0
+#endif
+
 #include "RuntimeJsImpl.h"
 
 #if (CC_CODE_IDE_DEBUG_SUPPORT > 0)

--- a/tools/simulator/frameworks/runtime-src/Classes/ide-support/RuntimeJsImpl.cpp
+++ b/tools/simulator/frameworks/runtime-src/Classes/ide-support/RuntimeJsImpl.cpp
@@ -29,6 +29,7 @@
 //
 //
 
+// NOTE: fix the conflict typedef between C++17 and one Windows header named 'rpcndr.h'
 #ifdef WIN32
 #define _HAS_STD_BYTE 0
 #endif


### PR DESCRIPTION
changeLog:
- fix simulator compiling on Win32, reference: https://studiofreya.com/2018/01/06/visual-studio-2017-with-cpp17-and-boost/#stdbyte-ambiguous-symbol-and-rpcndr.h