### PR TITLE
add resize event in Metal

### DIFF
--- a/cocos/bindings/event/EventDispatcher.cpp
+++ b/cocos/bindings/event/EventDispatcher.cpp
@@ -30,19 +30,23 @@
 #include "cocos/bindings/manual/jsb_global_init.h"
 
 namespace {
-se::Value _tickVal;
+se::Value                 _tickVal;
 std::vector<se::Object *> _jsTouchObjPool;
-se::Object *_jsTouchObjArray = nullptr;
-se::Object *_jsMouseEventObj = nullptr;
-se::Object *_jsKeyboardEventObj = nullptr;
-se::Object *_jsResizeEventObj = nullptr;
-se::Object *_jsOrientationEventObj = nullptr;
-bool _inited = false;
+se::Object *              _jsTouchObjArray       = nullptr;
+se::Object *              _jsMouseEventObj       = nullptr;
+se::Object *              _jsKeyboardEventObj    = nullptr;
+se::Object *              _jsResizeEventObj      = nullptr;
+se::Object *              _jsOrientationEventObj = nullptr;
+bool                      _inited                = false;
 } // namespace
 
 namespace cc {
 std::unordered_map<std::string, EventDispatcher::Node *> EventDispatcher::_listeners;
-uint32_t EventDispatcher::_hashListenerID = 1;
+uint32_t                                                 EventDispatcher::_hashListenerID = 1;
+
+bool EventDispatcher::initialized() {
+    return _inited;
+};
 
 void EventDispatcher::init() {
     _inited = true;
@@ -103,7 +107,7 @@ void EventDispatcher::dispatchTouchEvent(const struct TouchEvent &touchEvent) {
     }
 
     uint32_t touchIndex = 0;
-    int poolIndex = 0;
+    int      poolIndex  = 0;
     for (const auto &touch : touchEvent.touches) {
         se::Object *jsTouch = _jsTouchObjPool.at(poolIndex++);
         jsTouch->setProperty("identifier", se::Value(touch.index));
@@ -147,8 +151,8 @@ void EventDispatcher::dispatchMouseEvent(const struct MouseEvent &mouseEvent) {
         _jsMouseEventObj->root();
     }
 
-    const auto &xVal = se::Value(mouseEvent.x);
-    const auto &yVal = se::Value(mouseEvent.y);
+    const auto &           xVal = se::Value(mouseEvent.x);
+    const auto &           yVal = se::Value(mouseEvent.y);
     const MouseEvent::Type type = mouseEvent.type;
 
     if (type == MouseEvent::Type::WHEEL) {
@@ -162,23 +166,23 @@ void EventDispatcher::dispatchMouseEvent(const struct MouseEvent &mouseEvent) {
         _jsMouseEventObj->setProperty("y", yVal);
     }
 
-    const char *eventName = nullptr;
+    const char *eventName      = nullptr;
     const char *jsFunctionName = nullptr;
     switch (type) {
         case MouseEvent::Type::DOWN:
-            eventName = EVENT_MOUSE_DOWN;
+            eventName      = EVENT_MOUSE_DOWN;
             jsFunctionName = "onMouseDown";
             break;
         case MouseEvent::Type::MOVE:
-            eventName = EVENT_MOUSE_MOVE;
+            eventName      = EVENT_MOUSE_MOVE;
             jsFunctionName = "onMouseMove";
             break;
         case MouseEvent::Type::UP:
-            eventName = EVENT_MOUSE_UP;
+            eventName      = EVENT_MOUSE_UP;
             jsFunctionName = "onMouseUp";
             break;
         case MouseEvent::Type::WHEEL:
-            eventName = EVENT_MOUSE_WHEEL;
+            eventName      = EVENT_MOUSE_WHEEL;
             jsFunctionName = "onMouseWheel";
             break;
         default:
@@ -236,7 +240,7 @@ void EventDispatcher::dispatchTickEvent(float dt) {
     prevTime = std::chrono::steady_clock::now();
 
     se::ValueArray args;
-    long long milliSeconds = std::chrono::duration_cast<std::chrono::milliseconds>(prevTime - se::ScriptEngine::getInstance()->getStartTime()).count();
+    long long      milliSeconds = std::chrono::duration_cast<std::chrono::milliseconds>(prevTime - se::ScriptEngine::getInstance()->getStartTime()).count();
     args.push_back(se::Value((double)milliSeconds));
 
     _tickVal.toObject()->call(args, nullptr);
@@ -320,10 +324,10 @@ void EventDispatcher::doDispatchEvent(const char *eventName, const char *jsFunct
 }
 
 uint32_t EventDispatcher::addCustomEventListener(const std::string &eventName, const CustomEventListener &listener) {
-    Node *newNode = new Node();
-    newNode->listener = listener;
+    Node *newNode       = new Node();
+    newNode->listener   = listener;
     newNode->listenerID = _hashListenerID;
-    newNode->next = nullptr;
+    newNode->next       = nullptr;
 
     auto iter = _listeners.find(eventName);
     if (iter == _listeners.end()) {

--- a/cocos/bindings/event/EventDispatcher.h
+++ b/cocos/bindings/event/EventDispatcher.h
@@ -39,9 +39,9 @@ namespace cc {
 // Touch event related
 
 struct TouchInfo {
-    float x = 0;
-    float y = 0;
-    int index = 0;
+    float x     = 0;
+    float y     = 0;
+    int   index = 0;
 
     TouchInfo(float _x, float _y, int _index)
     : x(_x),
@@ -59,7 +59,7 @@ struct TouchEvent {
     };
 
     std::vector<TouchInfo> touches;
-    Type type = Type::UNKNOWN;
+    Type                   type = Type::UNKNOWN;
 };
 
 struct MouseEvent {
@@ -76,62 +76,62 @@ struct MouseEvent {
     // The button number that was pressed when the mouse event was fired: Left button=0, middle button=1 (if present), right button=2.
     // For mice configured for left handed use in which the button actions are reversed the values are instead read from right to left.
     unsigned short button = 0;
-    Type type = Type::UNKNOWN;
+    Type           type   = Type::UNKNOWN;
 };
 
 enum class KeyCode {
-    Backspace = 8,
-    Tab = 9,
-    NumLock = 12,
-    NumpadEnter = 20013,
-    Enter = 13,
-    ShiftRight = 20016,
-    ShiftLeft = 16,
-    ControlLeft = 17,
-    ControlRight = 20017,
-    AltRight = 20018,
-    AltLeft = 18,
-    CapsLock = 20,
-    Escape = 27,
-    Space = 32,
-    PageUp = 33,
-    PageDown = 34,
-    End = 35,
-    Home = 36,
-    ArrowLeft = 37,
-    ArrowUp = 38,
-    ArrowRight = 39,
-    ArrowDown = 40,
-    Delete = 46,
-    MetaLeft = 91,
-    ContextMenu = 20093,
-    MetaRight = 93,
+    Backspace      = 8,
+    Tab            = 9,
+    NumLock        = 12,
+    NumpadEnter    = 20013,
+    Enter          = 13,
+    ShiftRight     = 20016,
+    ShiftLeft      = 16,
+    ControlLeft    = 17,
+    ControlRight   = 20017,
+    AltRight       = 20018,
+    AltLeft        = 18,
+    CapsLock       = 20,
+    Escape         = 27,
+    Space          = 32,
+    PageUp         = 33,
+    PageDown       = 34,
+    End            = 35,
+    Home           = 36,
+    ArrowLeft      = 37,
+    ArrowUp        = 38,
+    ArrowRight     = 39,
+    ArrowDown      = 40,
+    Delete         = 46,
+    MetaLeft       = 91,
+    ContextMenu    = 20093,
+    MetaRight      = 93,
     NumpadMultiply = 106,
-    NumpadPlus = 107,
-    NumpadMinus = 109,
-    NumpadDecimal = 110,
-    NumpadDivide = 111,
-    Semicolon = 186,
-    Equal = 187,
-    Comma = 188,
-    Minus = 189,
-    Period = 190,
-    Slash = 191,
-    Backquote = 192,
-    BracketLeft = 219,
-    Backslash = 220,
-    BracketRight = 221,
-    Quote = 222,
-    NUMPAD_0 = 10048,
-    NUMPAD_1 = 10049,
-    NUMPAD_2 = 10050,
-    NUMPAD_3 = 10051,
-    NUMPAD_4 = 10052,
-    NUMPAD_5 = 10053,
-    NUMPAD_6 = 10054,
-    NUMPAD_7 = 10055,
-    NUMPAD_8 = 10056,
-    NUMPAD_9 = 10057
+    NumpadPlus     = 107,
+    NumpadMinus    = 109,
+    NumpadDecimal  = 110,
+    NumpadDivide   = 111,
+    Semicolon      = 186,
+    Equal          = 187,
+    Comma          = 188,
+    Minus          = 189,
+    Period         = 190,
+    Slash          = 191,
+    Backquote      = 192,
+    BracketLeft    = 219,
+    Backslash      = 220,
+    BracketRight   = 221,
+    Quote          = 222,
+    NUMPAD_0       = 10048,
+    NUMPAD_1       = 10049,
+    NUMPAD_2       = 10050,
+    NUMPAD_3       = 10051,
+    NUMPAD_4       = 10052,
+    NUMPAD_5       = 10053,
+    NUMPAD_6       = 10054,
+    NUMPAD_7       = 10055,
+    NUMPAD_8       = 10056,
+    NUMPAD_9       = 10057
 };
 
 struct KeyboardEvent {
@@ -142,12 +142,12 @@ struct KeyboardEvent {
         UNKNOWN
     };
 
-    int key = -1;
-    Action action = Action::UNKNOWN;
-    bool altKeyActive = false;
-    bool ctrlKeyActive = false;
-    bool metaKeyActive = false;
-    bool shiftKeyActive = false;
+    int    key            = -1;
+    Action action         = Action::UNKNOWN;
+    bool   altKeyActive   = false;
+    bool   ctrlKeyActive  = false;
+    bool   metaKeyActive  = false;
+    bool   shiftKeyActive = false;
     // TODO: support caps lock?
 };
 
@@ -156,11 +156,11 @@ public:
     std::string name;
     union {
         void *ptrVal;
-        long longVal;
-        int intVal;
+        long  longVal;
+        int   intVal;
         short shortVal;
-        char charVal;
-        bool boolVal;
+        char  charVal;
+        bool  boolVal;
     } args[10];
 
     CustomEvent(){};
@@ -171,6 +171,7 @@ class EventDispatcher {
 public:
     static void init();
     static void destroy();
+    static bool initialized();
 
     static void dispatchTouchEvent(const struct TouchEvent &touchEvent);
     static void dispatchMouseEvent(const struct MouseEvent &mouseEvent);
@@ -185,21 +186,21 @@ public:
 
     using CustomEventListener = std::function<void(const CustomEvent &)>;
     static uint32_t addCustomEventListener(const std::string &eventName, const CustomEventListener &listener);
-    static void removeCustomEventListener(const std::string &eventName, uint32_t listenerID);
-    static void removeAllCustomEventListeners(const std::string &eventName);
-    static void removeAllEventListeners();
-    static void dispatchCustomEvent(const CustomEvent &event);
+    static void     removeCustomEventListener(const std::string &eventName, uint32_t listenerID);
+    static void     removeAllCustomEventListeners(const std::string &eventName);
+    static void     removeAllEventListeners();
+    static void     dispatchCustomEvent(const CustomEvent &event);
 
 private:
     static void doDispatchEvent(const char *eventName, const char *jsFunctionName, const std::vector<se::Value> &args);
 
     struct Node {
         CustomEventListener listener;
-        uint32_t listenerID;
-        struct Node *next = nullptr;
+        uint32_t            listenerID;
+        struct Node *       next = nullptr;
     };
     static std::unordered_map<std::string, Node *> _listeners;
-    static uint32_t _hashListenerID; //simple increment hash
+    static uint32_t                                _hashListenerID; //simple increment hash
 };
 
 } // end of namespace cc

--- a/cocos/platform/mac/View.h
+++ b/cocos/platform/mac/View.h
@@ -25,13 +25,13 @@
 
 #import <AppKit/NSView.h>
 #ifdef CC_USE_METAL
-#import <MetalKit/MetalKit.h>
+    #import <MetalKit/MetalKit.h>
 #endif
 
-@interface View : NSView
+@interface View : NSView <CALayerDelegate>
 
 #ifdef CC_USE_METAL
-@property(nonatomic, assign) id<MTLDevice> device;
+@property (nonatomic, assign) id<MTLDevice> device;
 #endif
 
 @end

--- a/cocos/platform/mac/View.mm
+++ b/cocos/platform/mac/View.mm
@@ -24,23 +24,26 @@
 ****************************************************************************/
 
 #import "View.h"
+#import <AppKit/NSEvent.h>
+#import <AppKit/NSScreen.h>
+#import <AppKit/NSTouch.h>
+#import <QuartzCore/QuartzCore.h>
 #import "KeyCodeHelper.h"
 #import "cocos/bindings/event/EventDispatcher.h"
 #include "platform/Application.h"
-#import <AppKit/NSEvent.h>
-#import <AppKit/NSTouch.h>
-#import <AppKit/NSScreen.h>
-#import <QuartzCore/QuartzCore.h>
 
 @implementation View {
-    cc::MouseEvent _mouseEvent;
+    cc::MouseEvent    _mouseEvent;
     cc::KeyboardEvent _keyboardEvent;
 }
 
 #ifdef CC_USE_METAL
-- (CALayer *)makeBackingLayer
-{
-    return [CAMetalLayer layer];
+- (CALayer *)makeBackingLayer {
+    CAMetalLayer *layer              = [CAMetalLayer layer];
+    layer.delegate                   = self;
+    layer.autoresizingMask           = true;
+    layer.needsDisplayOnBoundsChange = true;
+    return layer;
 }
 #endif
 
@@ -49,15 +52,18 @@
         [self.window makeFirstResponder:self];
 
 #ifdef CC_USE_METAL
-        int pixelRatio = [[NSScreen mainScreen] backingScaleFactor];
-        CGSize size = CGSizeMake(frameRect.size.width * pixelRatio, frameRect.size.height * pixelRatio);
+        int    pixelRatio = [[NSScreen mainScreen] backingScaleFactor];
+        CGSize size       = CGSizeMake(frameRect.size.width * pixelRatio, frameRect.size.height * pixelRatio);
         // Create CAMetalLayer
         self.wantsLayer = YES;
         // Config metal layer
-        CAMetalLayer *layer = (CAMetalLayer*)self.layer;
-        layer.pixelFormat = MTLPixelFormatBGRA8Unorm;
-        layer.device = self.device = MTLCreateSystemDefaultDevice();
-        layer.drawableSize = size;
+        CAMetalLayer *layer = (CAMetalLayer *)self.layer;
+        layer.drawableSize  = size;
+        layer.pixelFormat   = MTLPixelFormatBGRA8Unorm;
+        layer.device = self.device     = MTLCreateSystemDefaultDevice();
+        layer.autoresizingMask         = kCALayerWidthSizable | kCALayerHeightSizable;
+        self.layerContentsRedrawPolicy = NSViewLayerContentsRedrawDuringViewResize;
+        self.layerContentsPlacement    = NSViewLayerContentsPlacementScaleProportionallyToFit;
 #endif
     }
     return self;
@@ -73,8 +79,30 @@
 }
 #endif
 
+- (void)displayLayer:(CALayer *)layer {
+    cc::Application::getInstance()->tick();
+}
+
+- (void)setFrameSize:(NSSize)newSize {
+    CAMetalLayer *layer = (CAMetalLayer *)self.layer;
+
+    CGSize nativeSize = [self convertSizeToBacking:newSize];
+    [super setFrameSize:newSize];
+    layer.drawableSize = nativeSize;
+    [self viewDidChangeBackingProperties];
+
+    if (cc::EventDispatcher::initialized())
+        cc::EventDispatcher::dispatchResizeEvent(static_cast<int>(nativeSize.width), static_cast<int>(nativeSize.height));
+}
+
+- (void)viewDidChangeBackingProperties {
+    [super viewDidChangeBackingProperties];
+    CAMetalLayer *layer = (CAMetalLayer *)self.layer;
+    layer.contentsScale = self.window.backingScaleFactor;
+}
+
 - (void)keyDown:(NSEvent *)event {
-    _keyboardEvent.key = translateKeycode(event.keyCode);
+    _keyboardEvent.key    = translateKeycode(event.keyCode);
     _keyboardEvent.action = [event isARepeat] ? cc::KeyboardEvent::Action::REPEAT
                                               : cc::KeyboardEvent::Action::PRESS;
     [self setModifierFlags:event];
@@ -82,7 +110,7 @@
 }
 
 - (void)keyUp:(NSEvent *)event {
-    _keyboardEvent.key = translateKeycode(event.keyCode);
+    _keyboardEvent.key    = translateKeycode(event.keyCode);
     _keyboardEvent.action = cc::KeyboardEvent::Action::RELEASE;
     [self setModifierFlags:event];
     cc::EventDispatcher::dispatchKeyboardEvent(_keyboardEvent);
@@ -164,10 +192,10 @@
     }
 
     if (fabs(deltaX) > 0.0 || fabs(deltaY) > 0.0) {
-        _mouseEvent.type = cc::MouseEvent::Type::WHEEL;
+        _mouseEvent.type   = cc::MouseEvent::Type::WHEEL;
         _mouseEvent.button = 0;
-        _mouseEvent.x = deltaX;
-        _mouseEvent.y = deltaY;
+        _mouseEvent.x      = deltaX;
+        _mouseEvent.y      = deltaY;
         cc::EventDispatcher::dispatchMouseEvent(_mouseEvent);
     }
 }
@@ -189,13 +217,13 @@
 }
 
 - (void)sendMouseEvent:(int)button type:(cc::MouseEvent::Type)type event:(NSEvent *)event {
-    const NSRect contentRect = [self frame];
-    const NSPoint pos = [event locationInWindow];
+    const NSRect  contentRect = [self frame];
+    const NSPoint pos         = [event locationInWindow];
 
-    _mouseEvent.type = type;
+    _mouseEvent.type   = type;
     _mouseEvent.button = button;
-    _mouseEvent.x = pos.x;
-    _mouseEvent.y = contentRect.size.height - pos.y;
+    _mouseEvent.x      = pos.x;
+    _mouseEvent.y      = contentRect.size.height - pos.y;
     cc::EventDispatcher::dispatchMouseEvent(_mouseEvent);
 }
 

--- a/cocos/renderer/gfx-metal/MTLUtils.mm
+++ b/cocos/renderer/gfx-metal/MTLUtils.mm
@@ -1596,7 +1596,12 @@ void mu::clearRenderArea(CCMTLDevice *device, id<MTLCommandBuffer> commandBuffer
 
     id<MTLRenderCommandEncoder> renderEncoder = [commandBuffer renderCommandEncoderWithDescriptor:renderPassDescriptor];
     [renderEncoder setViewport:(MTLViewport){0, 0, renderTargetWidth, renderTargetHeight}];
-    [renderEncoder setScissorRect:(MTLScissorRect){0, 0, static_cast<uint>(renderTargetWidth), static_cast<uint>(renderTargetHeight)}];
+    MTLScissorRect scissorArea = {static_cast<NSUInteger>(renderArea.x), static_cast<NSUInteger>(renderArea.y), static_cast<NSUInteger>(renderArea.width), static_cast<NSUInteger>(renderArea.height)};
+#if defined(CC_DEBUG) && (CC_DEBUG > 0)
+    scissorArea.width = MIN(scissorArea.width, renderTargetWidth - scissorArea.x);
+    scissorArea.height = MIN(scissorArea.height, renderTargetHeight - scissorArea.y);
+#endif
+    [renderEncoder setScissorRect:scissorArea];
     [renderEncoder setRenderPipelineState:gpuPSO->mtlRenderPipelineState];
     if (gpuPSO->mtlDepthStencilState) {
         [renderEncoder setStencilFrontReferenceValue:gpuPSO->stencilRefFront

--- a/templates/common/Classes/Game.cpp
+++ b/templates/common/Classes/Game.cpp
@@ -25,50 +25,53 @@
 #include "Game.h"
 #include "cocos/bindings/event/CustomEventTypes.h"
 #include "cocos/bindings/event/EventDispatcher.h"
-#include "cocos/bindings/manual/jsb_module_register.h"
-#include "cocos/bindings/manual/jsb_global.h"
 #include "cocos/bindings/jswrapper/SeApi.h"
-#include "cocos/bindings/event/EventDispatcher.h"
 #include "cocos/bindings/manual/jsb_classtype.h"
+#include "cocos/bindings/manual/jsb_global.h"
+#include "cocos/bindings/manual/jsb_module_register.h"
+#include "platform/device.h"
 
 Game::Game(int width, int height) : cc::Application(width, height) {}
 
-bool Game::init()
-{
+bool Game::init() {
     cc::Application::init();
-    
+
     se::ScriptEngine *se = se::ScriptEngine::getInstance();
-    
+
     jsb_set_xxtea_key("");
     jsb_init_file_operation_delegate();
-    
+
 #if defined(CC_DEBUG) && (CC_DEBUG > 0)
     // Enable debugger here
     jsb_enable_debugger("0.0.0.0", 6086, false);
 #endif
-    
+
     se->setExceptionCallback([](const char *location, const char *message, const char *stack) {
         // Send exception information to server like Tencent Bugly.
         CC_LOG_ERROR("\nUncaught Exception:\n - location :  %s\n - msg : %s\n - detail : \n      %s\n", location, message, stack);
     });
-    
+
     jsb_register_all_modules();
-    
+
     se->start();
-    
+
     se::AutoHandleScope hs;
     jsb_run_script("jsb-adapter/jsb-builtin.js");
     jsb_run_script("main.js");
-    
+
     se->addAfterCleanupHook([]() {
         JSBClassType::destroy();
     });
-    
+
+#if (CC_PLATFORM == CC_PLATFORM_MAC_IOS)
+    cc::Vec2 logicSize  = getViewLogicalSize();
+    float    pixelRatio = cc::Device::getDevicePixelRatio();
+    cc::EventDispatcher::dispatchResizeEvent(logicSize.x * pixelRatio, logicSize.y * pixelRatio);
+#endif
     return true;
 }
 
-void Game::onPause()
-{
+void Game::onPause() {
     cc::Application::onPause();
 
     cc::CustomEvent event;
@@ -77,10 +80,9 @@ void Game::onPause()
     cc::EventDispatcher::dispatchEnterBackgroundEvent();
 }
 
-void Game::onResume()
-{
+void Game::onResume() {
     cc::Application::onResume();
-    
+
     cc::CustomEvent event;
     event.name = EVENT_COME_TO_FOREGROUND;
     cc::EventDispatcher::dispatchCustomEvent(event);

--- a/templates/common/Classes/Game.cpp
+++ b/templates/common/Classes/Game.cpp
@@ -29,7 +29,10 @@
 #include "cocos/bindings/manual/jsb_classtype.h"
 #include "cocos/bindings/manual/jsb_global.h"
 #include "cocos/bindings/manual/jsb_module_register.h"
-#include "platform/device.h"
+
+#if (CC_PLATFORM == CC_PLATFORM_MAC_IOS)
+    #include "platform/device.h"
+#endif
 
 Game::Game(int width, int height) : cc::Application(width, height) {}
 

--- a/templates/mac/AppDelegate.mm
+++ b/templates/mac/AppDelegate.mm
@@ -12,9 +12,8 @@
 @implementation AppDelegate
 
 - (void)applicationDidFinishLaunching:(NSNotification*)aNotification {
-    int    pixelRatio = [[NSScreen mainScreen] backingScaleFactor];
-    NSRect rect       = NSMakeRect(200, 200, 960 * pixelRatio, 640 * pixelRatio);
-    _window           = [[NSWindow alloc] initWithContentRect:rect
+    NSRect rect = NSMakeRect(200, 200, 960, 640);
+    _window     = [[NSWindow alloc] initWithContentRect:rect
                                           styleMask:NSWindowStyleMaskMiniaturizable | NSWindowStyleMaskTitled | NSWindowStyleMaskClosable | NSWindowStyleMaskResizable
                                             backing:NSBackingStoreBuffered
                                               defer:NO];

--- a/templates/mac/AppDelegate.mm
+++ b/templates/mac/AppDelegate.mm
@@ -1,20 +1,20 @@
 #import "AppDelegate.h"
-#import "ViewController.h"
-#import "Game.h"
 #include <string>
+#import "Game.h"
+#import "ViewController.h"
 
-@interface AppDelegate ()
-{
+@interface AppDelegate () {
     NSWindow* _window;
-    Game* _game;
+    Game*     _game;
 }
 @end
 
 @implementation AppDelegate
 
-- (void)applicationDidFinishLaunching:(NSNotification *)aNotification {
-    NSRect rect = NSMakeRect(200, 200, 960, 640);
-    _window = [[NSWindow alloc] initWithContentRect:rect
+- (void)applicationDidFinishLaunching:(NSNotification*)aNotification {
+    int    pixelRatio = [[NSScreen mainScreen] backingScaleFactor];
+    NSRect rect       = NSMakeRect(200, 200, 960 * pixelRatio, 640 * pixelRatio);
+    _window           = [[NSWindow alloc] initWithContentRect:rect
                                           styleMask:NSWindowStyleMaskMiniaturizable | NSWindowStyleMaskTitled | NSWindowStyleMaskClosable | NSWindowStyleMaskResizable
                                             backing:NSBackingStoreBuffered
                                               defer:NO];
@@ -22,48 +22,47 @@
         NSLog(@"Failed to allocated the window.");
         return;
     }
-    
+
     _window.title = @"Cocos creator 3D Game";
-    
-    ViewController* viewController = [[ViewController alloc] initWithSize: rect];
-    _window.contentViewController = viewController;
-    _window.contentView = viewController.view;
+
+    ViewController* viewController = [[ViewController alloc] initWithSize:rect];
+    _window.contentViewController  = viewController;
+    _window.contentView            = viewController.view;
     [_window.contentView setWantsBestResolutionOpenGLSurface:YES];
     [_window makeKeyAndOrderFront:nil];
-        
+
     _game = new Game(rect.size.width, rect.size.height);
     _game->init();
 
-    [[NSNotificationCenter defaultCenter] addObserver:self 
-        selector:@selector(windowWillMiniaturizeNotification)name:NSWindowWillMiniaturizeNotification 
-        object:_window];
-    [[NSNotificationCenter defaultCenter] addObserver:self 
-        selector:@selector(windowDidDeminiaturizeNotification)name:NSWindowDidDeminiaturizeNotification 
-        object:_window];
+    [[NSNotificationCenter defaultCenter] addObserver:self
+                                             selector:@selector(windowWillMiniaturizeNotification)
+                                                 name:NSWindowWillMiniaturizeNotification
+                                               object:_window];
+    [[NSNotificationCenter defaultCenter] addObserver:self
+                                             selector:@selector(windowDidDeminiaturizeNotification)
+                                                 name:NSWindowDidDeminiaturizeNotification
+                                               object:_window];
 }
 
-- (void)windowWillMiniaturizeNotification
-{
+- (void)windowWillMiniaturizeNotification {
     _game->onPause();
 }
 
-- (void)windowDidDeminiaturizeNotification
-{
+- (void)windowDidDeminiaturizeNotification {
     _game->onResume();
 }
 
-- (NSWindow*)getWindow
-{
+- (NSWindow*)getWindow {
     return _window;
 }
 
-- (void)applicationWillTerminate:(NSNotification *)aNotification {
+- (void)applicationWillTerminate:(NSNotification*)aNotification {
     delete _game;
     //FIXME: will crash if relase it here.
     // [_window release];
 }
 
-- (BOOL)applicationShouldTerminateAfterLastWindowClosed:(NSApplication *)theApplication {
+- (BOOL)applicationShouldTerminateAfterLastWindowClosed:(NSApplication*)theApplication {
     return YES;
 }
 


### PR DESCRIPTION
tried to remove mu::renderEntireScreen, but failed in the _Camera_ Scene test. because MTLClear clear whole screen but here we need a viewport clear, scissor has no influence on the clear operation in Metal. the closest way to do this is https://developer.apple.com/documentation/metal/mtlrendercommandencoder/rendering_to_multiple_viewports_in_a_draw_command?language=objc , using multiple vp rendering in a single drawcall, but the _Camera_ test case seperate this scene into 4 passes, which makes it hard to apply multi-viewport-tech in.