### PR TITLE
fix application lifecycle issue on Android platform

### DIFF
--- a/cocos/platform/android/jni/JniCocosActivity.h
+++ b/cocos/platform/android/jni/JniCocosActivity.h
@@ -46,8 +46,8 @@ struct CocosApp {
     bool animating = true;
     bool running = false;
 
-    // Current state of the app's activity.  May be either APP_CMD_RESUME, APP_CMD_PAUSE.
-    int activityState = 0;
+    // Current state of the app.  May be either APP_CMD_RESUME, APP_CMD_PAUSE.
+    int appState = 0;
 };
 
 extern CocosApp cocosApp;


### PR DESCRIPTION
fix: https://github.com/cocos-creator/3d-tasks/issues/6937

## ChangeLog:
- fix application lifecycle issue on Android platform

## Issue Description
- the js engine doesn't care about when the CocosAcitivity is paused
- the js engien care when the Android Application is paused (But the android API doesn't provide any app paused event listener)
- resuming the EditBoxActivity pauses the CocosActivity
- so when the `onPause` callback invoked in js engine, we don't know if it's because of the EditBoxActivity or because the app gets in the background

## How to Fix
reference: https://developer.android.com/guide/components/activities/activity-lifecycle
I think the `onStart` `onStop` lifecycle is exactly what we need in js engine  
the EditBoxActivity pauses the CocosActivity, but not stops it.
the `onStop` lifecycle is invoked only when the app gets in the background  

So we say that when the CocosActivity is stopped, the app's `onPause` callback should be invoked  
the same as the `onStart` phase