### PR TITLE
fix: audio bug on iOS

### DIFF
--- a/cocos/audio/apple/AudioEngine-inl.mm
+++ b/cocos/audio/apple/AudioEngine-inl.mm
@@ -135,8 +135,9 @@ void AudioEngineInterruptionListenerCallback(void *user_data, UInt32 interruptio
                 ALOGD("AVAudioSessionInterruptionTypeEnded, application == UIApplicationStateActive, alcMakeContextCurrent(s_ALContext)");
                 NSError *error = nil;
                 [[AVAudioSession sharedInstance] setActive:YES error:&error];
-                if (alcGetCurrentContext() != nullptr)
+                if (alcGetCurrentContext() != nullptr) {
                     alcMakeContextCurrent(nullptr);
+                }
                 alcMakeContextCurrent(s_ALContext);
                 //IDEA:                if (Director::getInstance()->isPaused())
                 {

--- a/cocos/audio/apple/AudioEngine-inl.mm
+++ b/cocos/audio/apple/AudioEngine-inl.mm
@@ -135,6 +135,8 @@ void AudioEngineInterruptionListenerCallback(void *user_data, UInt32 interruptio
                 ALOGD("AVAudioSessionInterruptionTypeEnded, application == UIApplicationStateActive, alcMakeContextCurrent(s_ALContext)");
                 NSError *error = nil;
                 [[AVAudioSession sharedInstance] setActive:YES error:&error];
+                if (alcGetCurrentContext() != nullptr)
+                    alcMakeContextCurrent(nullptr);
                 alcMakeContextCurrent(s_ALContext);
                 //IDEA:                if (Director::getInstance()->isPaused())
                 {


### PR DESCRIPTION
最近测试同学反馈，iPhone手机运行我们的游戏过程中，闹钟响起出现banner ，向上滑动取消闹钟banner后，游戏的声音没法resume。问题能稳定复现。

调试定位到执行的逻辑：
![image](https://user-images.githubusercontent.com/13064618/119079372-90765900-ba2a-11eb-9854-c763eef84f25.png)

这种情况下闹钟响起InterruptionT并没有执行`alcMakeContextCurrent(nullptr);`，后续直接调用`alcMakeContextCurrent(nullptr);`并没有任何作用，会导致声音无法resume。
