### PR TITLE
Fix typo in the android template

### DIFF
--- a/templates/android/build/settings.gradle
+++ b/templates/android/build/settings.gradle
@@ -1,4 +1,4 @@
-include '::libcocos',':libservice',':instantapp',':CocosGame'
+include ':libcocos',':libservice',':instantapp',':CocosGame'
 project(':libcocos').projectDir = new File('${COCOS_ROOT}/cocos/platform/android/libcocos2dx')
 project(':instantapp').projectDir = new File('${NATIVE_DIR}/instantapp')
 project(':CocosGame').projectDir = new File('${NATIVE_DIR}/app')


### PR DESCRIPTION
The reason why the leading double colons won't cause any problems it's because of the inner implementation of Gradle's DefaultSettings.java.

https://github.com/gradle/gradle/blob/a44f852f120143a9f1e3870cc5bf1eb473ac1655/subprojects/core/src/main/java/org/gradle/initialization/DefaultSettings.java#L156

In short, there is a pre-created `rootProjectDescriptor`, `getProjectDescriptorRegistry().getProject(':')` returns the `rootProjectDescriptor` at startup (before enter the method), thus the code path of `include('::libcocos')` and `include (':libcocos')` are pretty much the same except extra initial loop of `include('::libcocos')`.