### PR TITLE
fix keys SHIFT, CTRL and ALT on MacOS platform

### DIFF
--- a/cocos/platform/mac/KeyCodeHelper.cpp
+++ b/cocos/platform/mac/KeyCodeHelper.cpp
@@ -158,6 +158,14 @@
 #define GLFW_KEY_LAST GLFW_KEY_MENU
 
 namespace {
+// Modifier Key State
+bool stateShiftLeft = false;
+bool stateShiftRight = false;
+bool stateControlLeft = false;
+bool stateControlRight = false;
+bool stateOptionLeft = false;
+bool stateOptionRight = false;
+
 // Refer to https://github.com/glfw/glfw/blob/master/src/cocoa_window.m.
 int keyCodes[0xff + 1] = {-1};
 
@@ -278,6 +286,63 @@ void init() {
     keyCodes[0x4E] = GLFW_KEY_KP_SUBTRACT;
 }
 } // namespace
+
+void updateModifierKeyState (int keyCodeInWeb) {
+    if (keyCodeInWeb == 16) {  // shift left
+        stateShiftLeft = !stateShiftLeft;
+    } else if (keyCodeInWeb == 20016) {  // shift right
+        stateShiftRight = !stateShiftRight;
+    } else if (keyCodeInWeb == 17) {  // ctrl left
+        stateControlLeft = !stateControlLeft;
+    } else if (keyCodeInWeb == 20017) {  // ctrl right
+        stateControlRight = !stateControlRight;
+    } else if (keyCodeInWeb == 18) {  // alt left
+        stateOptionLeft = !stateOptionLeft;
+    } else if (keyCodeInWeb == 20018) {  // alt right
+        stateOptionRight = !stateOptionRight;
+    }
+}
+
+cc::KeyboardEvent::Action getModifierKeyAction (int keyCodeInWeb) {
+    if (keyCodeInWeb == 16) {  // shift left
+        if (stateShiftLeft) {
+            return cc::KeyboardEvent::Action::PRESS;
+        } else {
+            return cc::KeyboardEvent::Action::RELEASE;
+        }
+    } else if (keyCodeInWeb == 20016) {  // shift right
+        if (stateShiftRight) {
+            return cc::KeyboardEvent::Action::PRESS;
+        } else {
+            return cc::KeyboardEvent::Action::RELEASE;
+        }
+    } else if (keyCodeInWeb == 17) {  // ctrl left
+        if (stateControlLeft) {
+            return cc::KeyboardEvent::Action::PRESS;
+        } else {
+            return cc::KeyboardEvent::Action::RELEASE;
+        }
+    } else if (keyCodeInWeb == 20017) {  // ctrl right
+        if (stateControlRight) {
+            return cc::KeyboardEvent::Action::PRESS;
+        } else {
+            return cc::KeyboardEvent::Action::RELEASE;
+        }
+    } else if (keyCodeInWeb == 18) {  // alt left
+        if (stateOptionLeft) {
+            return cc::KeyboardEvent::Action::PRESS;
+        } else {
+            return cc::KeyboardEvent::Action::RELEASE;
+        }
+    } else if (keyCodeInWeb == 20018) {  // alt right
+        if (stateOptionRight) {
+            return cc::KeyboardEvent::Action::PRESS;
+        } else {
+            return cc::KeyboardEvent::Action::RELEASE;
+        }
+    }
+    return cc::KeyboardEvent::Action::UNKNOWN;
+}
 
 // Refer to: https://github.com/cocos-creator/cocos2d-x-lite/blob/v2.4.0/cocos/platform/desktop/CCGLView-desktop.cpp.
 int translateKeycode(int keyCode) {

--- a/cocos/platform/mac/KeyCodeHelper.h
+++ b/cocos/platform/mac/KeyCodeHelper.h
@@ -23,6 +23,10 @@
  THE SOFTWARE.
 ****************************************************************************/
 
+#import "cocos/bindings/event/EventDispatcher.h"
+#include "platform/Application.h"
 #pragma once
 
 extern int translateKeycode(int);
+extern void updateModifierKeyState (int keyCodeInWeb);
+extern cc::KeyboardEvent::Action getModifierKeyAction (int keyCodeInWeb);

--- a/cocos/platform/mac/KeyCodeHelper.h
+++ b/cocos/platform/mac/KeyCodeHelper.h
@@ -24,7 +24,6 @@
 ****************************************************************************/
 
 #import "cocos/bindings/event/EventDispatcher.h"
-#include "platform/Application.h"
 #pragma once
 
 extern int translateKeycode(int);

--- a/cocos/platform/mac/View.mm
+++ b/cocos/platform/mac/View.mm
@@ -124,6 +124,24 @@
     cc::EventDispatcher::dispatchKeyboardEvent(_keyboardEvent);
 }
 
+- (void)flagsChanged:(NSEvent *)event {
+    int keyCode = translateKeycode(event.keyCode);
+    updateModifierKeyState(keyCode);
+    auto action = getModifierKeyAction(keyCode);
+    
+    // NOTE: in some cases, flagsChanged event may return some wrong keyCodes
+    // For example:
+    // - when you long press the capslock key, you may get the keyCode -1
+    // - when you press ctrl + space, you may get the keyCode 65
+    if (action == cc::KeyboardEvent::Action::UNKNOWN) {
+        return;
+    }
+    _keyboardEvent.key = keyCode;
+    _keyboardEvent.action = action;
+    [self setModifierFlags:event];
+    cc::EventDispatcher::dispatchKeyboardEvent(_keyboardEvent);
+}
+
 - (void)setModifierFlags:(NSEvent *)event {
     NSEventModifierFlags modifierFlags = event.modifierFlags;
     if (modifierFlags & NSEventModifierFlagShift)


### PR DESCRIPTION
re: https://github.com/cocos-creator/3d-tasks/issues/7529

changeLog:
- 修复 MacOS 平台上 SHIFT CTRL ALT 按键无效的问题

SHIFT CTRL ALT 这些按键为 ModifierKey，这类按键需要在 flagsChanged 事件回调里监听，keyDown 回调里监听不到