### PR TITLE
remove nativeSize() interface

### DIFF
--- a/cocos/platform/ios/Application-ios.mm
+++ b/cocos/platform/ios/Application-ios.mm
@@ -93,11 +93,8 @@ namespace {
     bool setCanvasCallback(se::Object *global) {
         auto viewLogicalSize = cc::Application::getInstance()->getViewLogicalSize();
 
-        int  nativeWidth  = static_cast<int>(viewLogicalSize.y * Device::getDevicePixelRatio());
-        int  nativeHeight = static_cast<int>(viewLogicalSize.x * Device::getDevicePixelRatio());
-        auto orientation  = cc::Device::getDeviceOrientation();
-        bool isLandscape  = (orientation == cc::Device::Orientation::LANDSCAPE_RIGHT || orientation == cc::Device::Orientation::LANDSCAPE_LEFT);
-        if (isLandscape) std::swap(nativeWidth, nativeHeight);
+        int  nativeWidth  = static_cast<int>(viewLogicalSize.x * Device::getDevicePixelRatio());
+        int  nativeHeight = static_cast<int>(viewLogicalSize.y * Device::getDevicePixelRatio());
 
         // https://stackoverflow.com/questions/5795978/string-format-for-intptr-t-and-uintptr-t/41897226#41897226
         // format intptr_t

--- a/cocos/platform/win32/Application-win32.cpp
+++ b/cocos/platform/win32/Application-win32.cpp
@@ -28,6 +28,12 @@
 #include "platform/Application.h"
 #include "platform/StdC.h" // need it to include Windows.h
 
+#include <MMSystem.h>
+#include <shellapi.h>
+#include <algorithm>
+#include <array>
+#include <memory>
+#include <sstream>
 #include "audio/include/AudioEngine.h"
 #include "base/AutoreleasePool.h"
 #include "base/Scheduler.h"
@@ -35,15 +41,10 @@
 #include "cocos/bindings/jswrapper/SeApi.h"
 #include "platform/FileUtils.h"
 #include "platform/win32/View-win32.h"
-#include <MMSystem.h>
-#include <algorithm>
-#include <array>
-#include <memory>
-#include <shellapi.h>
-#include <sstream>
 
 #include "pipeline/Define.h"
 #include "pipeline/RenderPipeline.h"
+#include "platform/Device.h"
 #include "renderer/GFXDeviceManager.h"
 
 extern std::shared_ptr<cc::View> cc_get_application_view();

--- a/cocos/renderer/frame-graph/DevicePass.cpp
+++ b/cocos/renderer/frame-graph/DevicePass.cpp
@@ -24,21 +24,21 @@
 ****************************************************************************/
 
 #include "DevicePass.h"
+#include <algorithm>
 #include "CallbackPass.h"
 #include "FrameGraph.h"
 #include "PassNode.h"
 #include "ResourceNode.h"
 #include "gfx-base/GFXCommandBuffer.h"
-#include <algorithm>
 
 namespace cc {
 namespace framegraph {
 
-DevicePass::DevicePass(const FrameGraph &graph, std::vector<PassNode *> const &subPassNodes) noexcept {
+DevicePass::DevicePass(const FrameGraph &graph, std::vector<PassNode *> const &subPassNodes) {
     std::vector<RenderTargetAttachment> attachments;
 
     for (const PassNode *const passNode : subPassNodes) {
-        append(graph, passNode, attachments);
+        append(graph, passNode, &attachments);
     }
 
     std::sort(attachments.begin(), attachments.end(), RenderTargetAttachment::Sorter());
@@ -61,14 +61,13 @@ DevicePass::DevicePass(const FrameGraph &graph, std::vector<PassNode *> const &s
     }
 }
 
-void DevicePass::execute() noexcept {
-    auto cmdBuff = gfx::Device::getInstance()->getCommandBuffer();
+void DevicePass::execute() {
+    auto *cmdBuff = gfx::Device::getInstance()->getCommandBuffer();
 
     begin(cmdBuff);
 
     for (Subpass &subPass : _subpasses) {
         for (LogicPass &pass : subPass.logicPasses) {
-
             gfx::Viewport &viewport = pass.customViewport ? pass.viewport : _viewport;
             gfx::Rect &    scissor  = pass.customViewport ? pass.scissor : _scissor;
 
@@ -90,7 +89,7 @@ void DevicePass::execute() noexcept {
     end(cmdBuff);
 }
 
-void DevicePass::append(const FrameGraph &graph, const PassNode *passNode, std::vector<RenderTargetAttachment> &attachments) noexcept {
+void DevicePass::append(const FrameGraph &graph, const PassNode *passNode, std::vector<RenderTargetAttachment> *attachments) {
     _subpasses.emplace_back();
     Subpass &subPass = _subpasses.back();
 
@@ -110,13 +109,13 @@ void DevicePass::append(const FrameGraph &graph, const PassNode *passNode, std::
     } while (passNode);
 }
 
-void DevicePass::append(const FrameGraph &graph, const RenderTargetAttachment &attachment, std::vector<RenderTargetAttachment> &attachments) noexcept {
-    auto it = std::find_if(attachments.begin(), attachments.end(), [&attachment](const RenderTargetAttachment &x) {
+void DevicePass::append(const FrameGraph &graph, const RenderTargetAttachment &attachment, std::vector<RenderTargetAttachment> *attachments) {
+    auto it = std::find_if(attachments->begin(), attachments->end(), [&attachment](const RenderTargetAttachment &x) {
         return attachment.desc.usage == x.desc.usage && attachment.desc.slot == x.desc.slot;
     });
 
-    if (it == attachments.end()) {
-        attachments.emplace_back(attachment);
+    if (it == attachments->end()) {
+        attachments->emplace_back(attachment);
         _usedRenderTargetSlotMask |= 1 << attachment.desc.slot;
     } else {
         const ResourceNode &resourceNodeA = graph.getResourceNode(it->textureHandle);
@@ -126,11 +125,11 @@ void DevicePass::append(const FrameGraph &graph, const RenderTargetAttachment &a
             if (attachment.storeOp != gfx::StoreOp::DISCARD) it->storeOp = attachment.storeOp;
         } else {
             CC_ASSERT(attachment.desc.usage == RenderTargetAttachment::Usage::COLOR);
-            attachments.emplace_back(attachment);
+            attachments->emplace_back(attachment);
 
             for (uint8_t i = 0; i < RenderTargetAttachment::DEPTH_STENCIL_SLOT_START; ++i) {
                 if ((_usedRenderTargetSlotMask & (1 << i)) == 0) {
-                    attachments.back().desc.slot = i;
+                    attachments->back().desc.slot = i;
                     break;
                 }
             }
@@ -138,41 +137,41 @@ void DevicePass::append(const FrameGraph &graph, const RenderTargetAttachment &a
     }
 }
 
-void DevicePass::begin(gfx::CommandBuffer *cmdBuff) noexcept {
+void DevicePass::begin(gfx::CommandBuffer *cmdBuff) {
     if (_attachments.empty()) return;
 
     gfx::RenderPassInfo            rpInfo;
     gfx::FramebufferInfo           fboInfo;
-    float                          clearDepth   = 1.f;
+    float                          clearDepth   = 1.F;
     uint                           clearStencil = 0;
     static std::vector<gfx::Color> clearColors;
     clearColors.clear();
     _viewport = gfx::Viewport();
     _scissor  = gfx::Rect();
-    for (uint i = 0; i < _attachments.size(); ++i) {
-        gfx::Texture *attachment = _attachments[i].renderTarget;
-        if (_attachments[i].attachment.desc.usage == RenderTargetAttachment::Usage::COLOR) {
+    for (const auto &attachElem : _attachments) {
+        gfx::Texture *attachment = attachElem.renderTarget;
+        if (attachElem.attachment.desc.usage == RenderTargetAttachment::Usage::COLOR) {
             rpInfo.colorAttachments.emplace_back();
             rpInfo.colorAttachments.back().format        = attachment ? attachment->getFormat() : gfx::Device::getInstance()->getColorFormat();
-            rpInfo.colorAttachments.back().loadOp        = _attachments[i].attachment.desc.loadOp;
-            rpInfo.colorAttachments.back().storeOp       = _attachments[i].attachment.storeOp;
-            rpInfo.colorAttachments.back().beginAccesses = _attachments[i].attachment.desc.beginAccesses;
-            rpInfo.colorAttachments.back().endAccesses   = _attachments[i].attachment.desc.endAccesses;
-            fboInfo.colorTextures.push_back(_attachments[i].renderTarget);
-            clearColors.emplace_back(_attachments[i].attachment.desc.clearColor);
-            _viewport.width = _scissor.width = attachment ? attachment->getWidth() : gfx::Device::getInstance()->getNativeWidth();
-            _viewport.height = _scissor.height = attachment ? attachment->getHeight() : gfx::Device::getInstance()->getNativeHeight();
+            rpInfo.colorAttachments.back().loadOp        = attachElem.attachment.desc.loadOp;
+            rpInfo.colorAttachments.back().storeOp       = attachElem.attachment.storeOp;
+            rpInfo.colorAttachments.back().beginAccesses = attachElem.attachment.desc.beginAccesses;
+            rpInfo.colorAttachments.back().endAccesses   = attachElem.attachment.desc.endAccesses;
+            fboInfo.colorTextures.push_back(attachElem.renderTarget);
+            clearColors.emplace_back(attachElem.attachment.desc.clearColor);
+            _viewport.width = _scissor.width = attachment ? attachment->getWidth() : gfx::Device::getInstance()->getWidth();
+            _viewport.height = _scissor.height = attachment ? attachment->getHeight() : gfx::Device::getInstance()->getHeight();
         } else {
             rpInfo.depthStencilAttachment.format         = attachment ? attachment->getFormat() : gfx::Device::getInstance()->getDepthStencilFormat();
-            rpInfo.depthStencilAttachment.depthLoadOp    = _attachments[i].attachment.desc.loadOp;
-            rpInfo.depthStencilAttachment.depthStoreOp   = _attachments[i].attachment.storeOp;
-            rpInfo.depthStencilAttachment.stencilLoadOp  = _attachments[i].attachment.desc.loadOp;
-            rpInfo.depthStencilAttachment.stencilStoreOp = _attachments[i].attachment.storeOp;
-            rpInfo.depthStencilAttachment.beginAccesses  = _attachments[i].attachment.desc.beginAccesses;
-            rpInfo.depthStencilAttachment.endAccesses    = _attachments[i].attachment.desc.endAccesses;
-            fboInfo.depthStencilTexture                  = _attachments[i].renderTarget;
-            clearDepth                                   = _attachments[i].attachment.desc.clearDepth;
-            clearStencil                                 = _attachments[i].attachment.desc.clearStencil;
+            rpInfo.depthStencilAttachment.depthLoadOp    = attachElem.attachment.desc.loadOp;
+            rpInfo.depthStencilAttachment.depthStoreOp   = attachElem.attachment.storeOp;
+            rpInfo.depthStencilAttachment.stencilLoadOp  = attachElem.attachment.desc.loadOp;
+            rpInfo.depthStencilAttachment.stencilStoreOp = attachElem.attachment.storeOp;
+            rpInfo.depthStencilAttachment.beginAccesses  = attachElem.attachment.desc.beginAccesses;
+            rpInfo.depthStencilAttachment.endAccesses    = attachElem.attachment.desc.endAccesses;
+            fboInfo.depthStencilTexture                  = attachElem.renderTarget;
+            clearDepth                                   = attachElem.attachment.desc.clearDepth;
+            clearStencil                                 = attachElem.attachment.desc.clearStencil;
         }
     }
 
@@ -191,7 +190,7 @@ void DevicePass::begin(gfx::CommandBuffer *cmdBuff) noexcept {
 void DevicePass::next(gfx::CommandBuffer *cmdBuff) noexcept {
 }
 
-void DevicePass::end(gfx::CommandBuffer *cmdBuff) noexcept {
+void DevicePass::end(gfx::CommandBuffer *cmdBuff) {
     if (!_renderPass.get() || !_fbo.get()) return;
 
     cmdBuff->endRenderPass();

--- a/cocos/renderer/frame-graph/DevicePass.h
+++ b/cocos/renderer/frame-graph/DevicePass.h
@@ -25,12 +25,12 @@
 
 #pragma once
 
+#include <string>
+#include <vector>
 #include "CallbackPass.h"
 #include "DevicePassResourceTable.h"
 #include "RenderTargetAttachment.h"
 #include "gfx-base/GFXDef.h"
-#include <string>
-#include <vector>
 
 namespace cc {
 namespace framegraph {
@@ -38,14 +38,14 @@ namespace framegraph {
 class DevicePass final {
 public:
     DevicePass() = delete;
-    DevicePass(const FrameGraph &graph, std::vector<PassNode *> const &subPassNodes) noexcept;
+    DevicePass(const FrameGraph &graph, std::vector<PassNode *> const &subPassNodes);
     DevicePass(const DevicePass &) = delete;
     DevicePass(DevicePass &&)      = delete;
     ~DevicePass()                  = default;
     DevicePass &operator=(const DevicePass &) = delete;
     DevicePass &operator=(DevicePass &&) = delete;
 
-    void execute() noexcept;
+    void execute();
 
 private:
     struct LogicPass final {
@@ -60,15 +60,15 @@ private:
     };
 
     struct Attachment final {
-        RenderTargetAttachment       attachment;
-        gfx::Texture *               renderTarget{nullptr};
+        RenderTargetAttachment attachment;
+        gfx::Texture *         renderTarget{nullptr};
     };
 
-    void append(const FrameGraph &graph, const PassNode *passNode, std::vector<RenderTargetAttachment> &attachments) noexcept;
-    void append(const FrameGraph &graph, const RenderTargetAttachment &attachment, std::vector<RenderTargetAttachment> &attachments) noexcept;
-    void begin(gfx::CommandBuffer *cmdBuff) noexcept;
+    void append(const FrameGraph &graph, const PassNode *passNode, std::vector<RenderTargetAttachment> *attachments);
+    void append(const FrameGraph &graph, const RenderTargetAttachment &attachment, std::vector<RenderTargetAttachment> *attachments);
+    void begin(gfx::CommandBuffer *cmdBuff);
     void next(gfx::CommandBuffer *cmdBuff) noexcept;
-    void end(gfx::CommandBuffer *cmdBuff) noexcept;
+    void end(gfx::CommandBuffer *cmdBuff);
 
     std::vector<Subpass>    _subpasses{};
     std::vector<Attachment> _attachments{};

--- a/cocos/renderer/frame-graph/RenderTargetAttachment.h
+++ b/cocos/renderer/frame-graph/RenderTargetAttachment.h
@@ -48,8 +48,8 @@ struct RenderTargetAttachment final {
         uint8_t writeMask{0xff};
         LoadOp  loadOp{LoadOp::DISCARD};
         Color   clearColor;
-        float   clearDepth{1.f};
-        uint8_t clearStencil{0u};
+        float   clearDepth{1.F};
+        uint8_t clearStencil{0U};
 
         std::vector<gfx::AccessType> beginAccesses;
         std::vector<gfx::AccessType> endAccesses;
@@ -70,13 +70,15 @@ struct RenderTargetAttachment final {
 };
 
 CC_INLINE bool RenderTargetAttachment::Sorter::operator()(const RenderTargetAttachment &a1, const RenderTargetAttachment &a2) const noexcept {
+    bool res = false;
     if (a1.desc.usage < a2.desc.usage) {
-        return true;
+        res = true;
     } else if (a1.desc.usage == a2.desc.usage) {
-        return a1.desc.slot < a2.desc.slot;
+        res = a1.desc.slot < a2.desc.slot;
     } else {
-        return false;
+        res = false;
     }
+    return res;
 }
 
 } // namespace framegraph

--- a/cocos/renderer/frame-graph/Resource.h
+++ b/cocos/renderer/frame-graph/Resource.h
@@ -41,14 +41,14 @@ namespace framegraph {
 
 template <typename DescriptorType>
 struct ResourceDescriptorHasher final {
-    CC_INLINE uint32_t operator()(const DescriptorType &desc) const {
+    CC_INLINE uint32_t operator()(const DescriptorType & /*desc*/) const {
         return 1;
     }
 };
 
 template <typename DeviceResourceType, typename DescriptorType>
 struct DeviceResourceCreator final {
-    CC_INLINE DeviceResourceType *operator()(const DescriptorType &desc) const {
+    CC_INLINE DeviceResourceType *operator()(const DescriptorType & /*desc*/) const {
         return nullptr;
     }
 };

--- a/cocos/renderer/frame-graph/ResourceAllocator.h
+++ b/cocos/renderer/frame-graph/ResourceAllocator.h
@@ -43,10 +43,10 @@ public:
     ResourceAllocator &operator=(ResourceAllocator &&) = delete;
 
     static ResourceAllocator &getInstance() noexcept;
-    DeviceResourceType *      alloc(const DescriptorType &desc, DescriptorHash const key) noexcept;
-    void                      free(const DescriptorType &desc, DescriptorHash const key, DeviceResourceType *const resource) noexcept;
-    CC_INLINE void               tick() noexcept;
-    void                      gc(uint32_t const unusedFrameCount) noexcept;
+    DeviceResourceType *      alloc(const DescriptorType &desc, DescriptorHash key) noexcept;
+    void                      free(const DescriptorType &desc, DescriptorHash key, DeviceResourceType *resource) noexcept;
+    CC_INLINE void            tick() noexcept;
+    void                      gc(uint32_t unusedFrameCount) noexcept;
 
 private:
     using DeviceResourcePtr = DeviceResourceType *;
@@ -67,8 +67,8 @@ private:
     ResourceAllocator() noexcept = default;
     ~ResourceAllocator()         = default;
     template <typename Cache>
-    typename Bucket::Pool *getPool(DescriptorHash const key, Cache &from) noexcept;
-    BucketGC &             getBucketGC(DescriptorHash const key) noexcept;
+    typename Bucket::Pool *getPool(DescriptorHash key, Cache &from) noexcept;
+    BucketGC &             getBucketGC(DescriptorHash key) noexcept;
 
     std::vector<BucketGC> _free{};
     std::vector<Bucket>   _inUse{};
@@ -111,7 +111,7 @@ DeviceResourceType *ResourceAllocator<DeviceResourceType, DescriptorType, Device
 }
 
 template <typename DeviceResourceType, typename DescriptorType, typename DeviceResourceCreatorType>
-void ResourceAllocator<DeviceResourceType, DescriptorType, DeviceResourceCreatorType>::free(const DescriptorType &desc, DescriptorHash const key, DeviceResourceType *const resource) noexcept {
+void ResourceAllocator<DeviceResourceType, DescriptorType, DeviceResourceCreatorType>::free(const DescriptorType & /*desc*/, DescriptorHash const key, DeviceResourceType *const resource) noexcept {
     auto *pool = getPool(key, _inUse);
     CC_ASSERT(!pool->empty());
 

--- a/cocos/renderer/gfx-agent/DeviceAgent.h
+++ b/cocos/renderer/gfx-agent/DeviceAgent.h
@@ -88,8 +88,6 @@ public:
     SurfaceTransform getSurfaceTransform() const override { return _actor->getSurfaceTransform(); }
     uint             getWidth() const override { return _actor->getWidth(); }
     uint             getHeight() const override { return _actor->getHeight(); }
-    uint             getNativeWidth() const override { return _actor->getNativeWidth(); }
-    uint             getNativeHeight() const override { return _actor->getNativeHeight(); }
     MemoryStatus &   getMemoryStatus() override { return _actor->getMemoryStatus(); }
     uint             getNumDrawCalls() const override { return _actor->getNumDrawCalls(); }
     uint             getNumInstances() const override { return _actor->getNumInstances(); }

--- a/cocos/renderer/gfx-base/GFXDef.h
+++ b/cocos/renderer/gfx-base/GFXDef.h
@@ -59,8 +59,7 @@ struct DeviceInfo {
     uintptr_t          windowHandle = 0U;
     uint               width        = 0U;
     uint               height       = 0U;
-    uint               nativeWidth  = 0U;
-    uint               nativeHeight = 0U;
+    float              pixelRatio   = 1.0F;
     BindingMappingInfo bindingMappingInfo;
 };
 

--- a/cocos/renderer/gfx-base/GFXDevice.cpp
+++ b/cocos/renderer/gfx-base/GFXDevice.cpp
@@ -58,8 +58,7 @@ Format Device::getDepthStencilFormat() const {
 bool Device::initialize(const DeviceInfo &info) {
     _width        = info.width;
     _height       = info.height;
-    _nativeWidth  = info.nativeWidth;
-    _nativeHeight = info.nativeHeight;
+    _pixelRatio   = info.pixelRatio;
     _windowHandle = info.windowHandle;
 
     _bindingMappingInfo = info.bindingMappingInfo;
@@ -78,7 +77,8 @@ void Device::destroy() {
 
     _bindingMappingInfo.bufferOffsets.clear();
     _bindingMappingInfo.samplerOffsets.clear();
-    _width = _height = _nativeWidth = _nativeHeight = _windowHandle = 0U;
+    _width = _height = _windowHandle = 0U;
+    _pixelRatio                      = 1.0F;
 }
 
 } // namespace gfx

--- a/cocos/renderer/gfx-base/GFXDevice.h
+++ b/cocos/renderer/gfx-base/GFXDevice.h
@@ -63,8 +63,7 @@ public:
     virtual SurfaceTransform getSurfaceTransform() const { return _transform; }
     virtual uint             getWidth() const { return _width; }
     virtual uint             getHeight() const { return _height; }
-    virtual uint             getNativeWidth() const { return _nativeWidth; }
-    virtual uint             getNativeHeight() const { return _nativeHeight; }
+    virtual float            devicePixelRatio() const { return _pixelRatio; }
     virtual MemoryStatus &   getMemoryStatus() { return _memoryStatus; }
     virtual uint             getNumDrawCalls() const { return _numDrawCalls; }
     virtual uint             getNumInstances() const { return _numInstances; }
@@ -153,10 +152,9 @@ protected:
     String             _vendor;
     String             _version;
     bool               _features[static_cast<uint>(Feature::COUNT)];
-    uint               _width        = 0;
-    uint               _height       = 0;
-    uint               _nativeWidth  = 0;
-    uint               _nativeHeight = 0;
+    uint               _width      = 0;
+    uint               _height     = 0;
+    float              _pixelRatio = 1.0F;
     MemoryStatus       _memoryStatus;
     uintptr_t          _windowHandle = 0;
     Context *          _context      = nullptr;

--- a/cocos/renderer/gfx-empty/EmptyDevice.cpp
+++ b/cocos/renderer/gfx-empty/EmptyDevice.cpp
@@ -44,21 +44,21 @@
 namespace cc {
 namespace gfx {
 
-EmptyDevice *EmptyDevice::_instance = nullptr;
+EmptyDevice *EmptyDevice::instance = nullptr;
 
 EmptyDevice *EmptyDevice::getInstance() {
-    return EmptyDevice::_instance;
+    return EmptyDevice::instance;
 }
 
 EmptyDevice::EmptyDevice() {
-    EmptyDevice::_instance  = this;
+    EmptyDevice::instance = this;
 }
 
 EmptyDevice::~EmptyDevice() {
-    EmptyDevice::_instance = nullptr;
+    EmptyDevice::instance = nullptr;
 }
 
-bool EmptyDevice::doInit(const DeviceInfo &info) {
+bool EmptyDevice::doInit(const DeviceInfo & /*info*/) {
     ContextInfo ctxInfo;
     ctxInfo.windowHandle = _windowHandle;
 
@@ -81,7 +81,6 @@ bool EmptyDevice::doInit(const DeviceInfo &info) {
 
     CC_LOG_INFO("Empty device initialized.");
     CC_LOG_INFO("SCREEN_SIZE: %d x %d", _width, _height);
-    CC_LOG_INFO("NATIVE_SIZE: %d x %d", _nativeWidth, _nativeHeight);
 
     return true;
 }
@@ -93,8 +92,8 @@ void EmptyDevice::doDestroy() {
 }
 
 void EmptyDevice::resize(uint width, uint height) {
-    _width = _nativeWidth = width;
-    _height = _nativeHeight = height;
+    _width  = width;
+    _height = height;
 }
 
 void EmptyDevice::acquire() {
@@ -104,7 +103,7 @@ void EmptyDevice::present() {
     std::this_thread::sleep_for(std::chrono::milliseconds(16));
 }
 
-CommandBuffer *EmptyDevice::createCommandBuffer(const CommandBufferInfo &info, bool Emptyhas) {
+CommandBuffer *EmptyDevice::createCommandBuffer(const CommandBufferInfo & /*info*/, bool /*Emptyhas*/) {
     return CC_NEW(EmptyCommandBuffer());
 }
 

--- a/cocos/renderer/gfx-empty/EmptyDevice.h
+++ b/cocos/renderer/gfx-empty/EmptyDevice.h
@@ -57,7 +57,7 @@ public:
     void acquire() override;
     void present() override;
 
-    CommandBuffer *      createCommandBuffer(const CommandBufferInfo &info, bool Emptyhas) override;
+    CommandBuffer *      createCommandBuffer(const CommandBufferInfo &info, bool emptyhas) override;
     Queue *              createQueue() override;
     Buffer *             createBuffer() override;
     Texture *            createTexture() override;
@@ -75,7 +75,7 @@ public:
     void                 copyBuffersToTexture(const uint8_t *const *buffers, Texture *dst, const BufferTextureCopy *regions, uint count) override;
 
 protected:
-    static EmptyDevice *_instance;
+    static EmptyDevice *instance;
 
     friend class DeviceManager;
 

--- a/cocos/renderer/gfx-gles2/GLES2Device.cpp
+++ b/cocos/renderer/gfx-gles2/GLES2Device.cpp
@@ -216,7 +216,6 @@ bool GLES2Device::doInit(const DeviceInfo &info) {
     CC_LOG_INFO("VENDOR: %s", _vendor.c_str());
     CC_LOG_INFO("VERSION: %s", _version.c_str());
     CC_LOG_INFO("SCREEN_SIZE: %d x %d", _width, _height);
-    CC_LOG_INFO("NATIVE_SIZE: %d x %d", _nativeWidth, _nativeHeight);
     CC_LOG_INFO("COMPRESSED_FORMATS: %s", compressedFmts.c_str());
     CC_LOG_INFO("USE_VAO: %s", _gpuExtensionRegistry->useVAO ? "true" : "false");
     CC_LOG_INFO("FRAMEBUFFER_FETCH: %s", fbfLevelStr.c_str());

--- a/cocos/renderer/gfx-gles3/GLES3Device.cpp
+++ b/cocos/renderer/gfx-gles3/GLES3Device.cpp
@@ -202,7 +202,6 @@ bool GLES3Device::doInit(const DeviceInfo &info) {
     CC_LOG_INFO("VENDOR: %s", _vendor.c_str());
     CC_LOG_INFO("VERSION: %s", _version.c_str());
     CC_LOG_INFO("SCREEN_SIZE: %d x %d", _width, _height);
-    CC_LOG_INFO("NATIVE_SIZE: %d x %d", _nativeWidth, _nativeHeight);
     CC_LOG_INFO("COMPRESSED_FORMATS: %s", compressedFmts.c_str());
     CC_LOG_INFO("PIXEL_LOCAL_STORAGE: level %d, size %d", _gpuExtensionRegistry->mPLS, _gpuExtensionRegistry->mPLSsize);
     CC_LOG_INFO("FRAMEBUFFER_FETCH: %s", fbfLevelStr.c_str());

--- a/cocos/renderer/gfx-metal/MTLDevice.mm
+++ b/cocos/renderer/gfx-metal/MTLDevice.mm
@@ -111,8 +111,8 @@ bool CCMTLDevice::doInit(const DeviceInfo &info) {
     // Persistent depth stencil texture
     MTLTextureDescriptor *dssDescriptor = [[MTLTextureDescriptor alloc] init];
     dssDescriptor.pixelFormat = mu::getSupportedDepthStencilFormat(mtlDevice, gpuFamily, _caps.depthBits);
-    dssDescriptor.width = info.nativeWidth;
-    dssDescriptor.height = info.nativeHeight;
+    dssDescriptor.width = info.width;
+    dssDescriptor.height = info.height;
     dssDescriptor.storageMode = MTLStorageModePrivate;
     dssDescriptor.usage = MTLTextureUsageRenderTarget;
     _dssTex = [mtlDevice newTextureWithDescriptor:dssDescriptor];

--- a/cocos/renderer/gfx-validator/DeviceValidator.h
+++ b/cocos/renderer/gfx-validator/DeviceValidator.h
@@ -79,8 +79,6 @@ public:
     SurfaceTransform getSurfaceTransform() const override { return _actor->getSurfaceTransform(); }
     uint             getWidth() const override { return _actor->getWidth(); }
     uint             getHeight() const override { return _actor->getHeight(); }
-    uint             getNativeWidth() const override { return _actor->getNativeWidth(); }
-    uint             getNativeHeight() const override { return _actor->getNativeHeight(); }
     MemoryStatus &   getMemoryStatus() override { return _actor->getMemoryStatus(); }
     uint             getNumDrawCalls() const override { return _actor->getNumDrawCalls(); }
     uint             getNumInstances() const override { return _actor->getNumInstances(); }

--- a/cocos/renderer/gfx-vulkan/VKDevice.cpp
+++ b/cocos/renderer/gfx-vulkan/VKDevice.cpp
@@ -432,7 +432,6 @@ bool CCVKDevice::doInit(const DeviceInfo &info) {
     CC_LOG_INFO("VENDOR: %s", _vendor.c_str());
     CC_LOG_INFO("VERSION: %s", _version.c_str());
     CC_LOG_INFO("SCREEN_SIZE: %d x %d", _width, _height);
-    CC_LOG_INFO("NATIVE_SIZE: %d x %d", _nativeWidth, _nativeHeight);
     CC_LOG_INFO("INSTANCE_LAYERS: %s", instanceLayers.c_str());
     CC_LOG_INFO("INSTANCE_EXTENSIONS: %s", instanceExtensions.c_str());
     CC_LOG_INFO("DEVICE_LAYERS: %s", deviceLayers.c_str());
@@ -694,8 +693,8 @@ bool CCVKDevice::checkSwapchainStatus() {
         context->swapchainCreateInfo.imageExtent.width  = _width;
         context->swapchainCreateInfo.imageExtent.height = _height;
     } else {
-        _nativeWidth = _width = context->swapchainCreateInfo.imageExtent.width = newWidth;
-        _nativeHeight = _height = context->swapchainCreateInfo.imageExtent.height = newHeight;
+        _width = context->swapchainCreateInfo.imageExtent.width = newWidth;
+        _height = context->swapchainCreateInfo.imageExtent.height = newHeight;
     }
 
     if (newWidth == 0 || newHeight == 0) {

--- a/tools/tojs/gfx.ini
+++ b/tools/tojs/gfx.ini
@@ -72,7 +72,7 @@ skip = Buffer::[Buffer getDevice initialize update],
        Device::[Device copyBuffersToTexture createBuffer createTexture getInstance flushCommands$],
        Context::[Context]
 
-getter_setter = Device::[gfxAPI surfaceTransform deviceName width height nativeWidth nativeHeight memoryStatus queue commandBuffer renderer vendor numDrawCalls numInstances numTris colorFormat depthStencilFormat capabilities],
+getter_setter = Device::[gfxAPI surfaceTransform deviceName width height memoryStatus queue commandBuffer renderer vendor numDrawCalls numInstances numTris colorFormat depthStencilFormat capabilities],
                 Shader::[name stages attributes blocks samplers],
                 Texture::[type usage format width height depth layerCount levelCount size samples flags],
                 Queue::[type],


### PR DESCRIPTION
配对的issue: https://github.com/cocos-creator/engine/pull/8745
改为了所有进出device的size全都是nativeSize，因为device这里是不需要关心逻辑大小的，针对实际的frameBuffer大小就可以了。