### PR TITLE
Fix js string lose \0

### DIFF
--- a/cocos/network/WebSocket-apple.mm
+++ b/cocos/network/WebSocket-apple.mm
@@ -168,10 +168,9 @@ static std::vector<cocos2d::network::WebSocket*>* __websocketInstances = nullptr
 {
     if (!_isDestroyed)
     {
-        std::string message = [string UTF8String];
         cocos2d::network::WebSocket::Data data;
-        data.bytes = (char*)message.c_str();
-        data.len = message.length() + 1;
+        data.bytes = (char*) [string cStringUsingEncoding:NSUTF8StringEncoding];
+        data.len = [string length];
         data.isBinary = false;
         data.issued = 0;
         data.ext = nullptr;
@@ -290,7 +289,7 @@ void WebSocket::send(const std::string& message)
 {
     if ([_impl getReadyState] == State::OPEN)
     {
-        NSString* str = [[NSString alloc] initWithUTF8String:message.c_str()];
+        NSString* str = [[NSString alloc] initWithBytes:message.data() length:message.length() encoding:NSUTF8StringEncoding];
         [_impl sendString:str];
     }
     else

--- a/cocos/scripting/js-bindings/jswrapper/v8/Utils.cpp
+++ b/cocos/scripting/js-bindings/jswrapper/v8/Utils.cpp
@@ -67,7 +67,7 @@ namespace se {
                     break;
                 case Value::Type::String:
                 {
-                    v8::MaybeLocal<v8::String> str = v8::String::NewFromUtf8(isolate, v.toString().c_str(), v8::NewStringType::kNormal);
+                    v8::MaybeLocal<v8::String> str = v8::String::NewFromUtf8(isolate, v.toString().data(), v8::NewStringType::kNormal, (int) v.toString().length());
                     if (!str.IsEmpty())
                         *outJsVal = str.ToLocalChecked();
                     else

--- a/cocos/scripting/js-bindings/manual/jsb_websocket.cpp
+++ b/cocos/scripting/js-bindings/manual/jsb_websocket.cpp
@@ -148,7 +148,7 @@ void JSB_WebSocketDelegate::onMessage(WebSocket* ws, const WebSocket::Data& data
             }
             else
             {// Normal string
-                dataVal.setString(data.bytes);
+                dataVal.setString(std::string(data.bytes, data.len));
             }
 
             if (dataVal.isNullOrUndefined())


### PR DESCRIPTION
Stomp 用 \0 作为命令结束，string转换丢失\0，导致stomp连接失败