### PR TITLE
fix texture memory leak on Metal renderer.

### DIFF
--- a/cocos/renderer/gfx-base/GFXDef-common.h
+++ b/cocos/renderer/gfx-base/GFXDef-common.h
@@ -652,10 +652,11 @@ CC_ENUM_OPERATORS(DynamicStateFlagBit);
 using DynamicStateList = vector<DynamicStateFlagBit>;
 
 enum class StencilFace {
-    FRONT,
-    BACK,
-    ALL,
+    FRONT = 0x1,
+    BACK  = 0x2,
+    ALL   = 0x3,
 };
+CC_ENUM_OPERATORS(StencilFace);
 
 enum class DescriptorType : FlagBits {
     UNKNOWN                = 0,

--- a/cocos/renderer/gfx-metal/MTLTexture.mm
+++ b/cocos/renderer/gfx-metal/MTLTexture.mm
@@ -131,6 +131,7 @@ void CCMTLTexture::doDestroy() {
 
     std::function<void(void)> destroyFunc = [=]() {
         if (mtlTexure) {
+            [mtlTexure setPurgeableState:MTLPurgeableStateEmpty];
             [mtlTexure release];
         }
     };
@@ -159,6 +160,7 @@ void CCMTLTexture::doResize(uint width, uint height, uint size) {
     if (oldMTLTexture) {
         std::function<void(void)> destroyFunc = [=]() {
             if (oldMTLTexture) {
+                [oldMTLTexture setPurgeableState:MTLPurgeableStateEmpty];
                 [oldMTLTexture release];
             }
         };


### PR DESCRIPTION
Just switch two scene will reproduce this issue.
[NewProject_2.zip](https://github.com/cocos-creator/engine-native/files/6654522/NewProject_2.zip)
