### PR TITLE
fix texture memory leak on Metal renderer.

### DIFF
--- a/cocos/renderer/gfx-metal/MTLTexture.mm
+++ b/cocos/renderer/gfx-metal/MTLTexture.mm
@@ -131,6 +131,7 @@ void CCMTLTexture::doDestroy() {
 
     std::function<void(void)> destroyFunc = [=]() {
         if (mtlTexure) {
+            [mtlTexure setPurgeableState:MTLPurgeableStateEmpty];
             [mtlTexure release];
         }
     };
@@ -159,6 +160,7 @@ void CCMTLTexture::doResize(uint width, uint height, uint size) {
     if (oldMTLTexture) {
         std::function<void(void)> destroyFunc = [=]() {
             if (oldMTLTexture) {
+                [oldMTLTexture setPurgeableState:MTLPurgeableStateEmpty];
                 [oldMTLTexture release];
             }
         };


### PR DESCRIPTION
Just switch two scene will reproduce this issue.
[NewProject_2.zip](https://github.com/cocos-creator/engine-native/files/6654522/NewProject_2.zip)