### PR TITLE
CameraUBO和GlobalUBO更新机制替换为Buffer::update的memcpy

### DIFF
--- a/cocos/renderer/pipeline/Define.cpp
+++ b/cocos/renderer/pipeline/Define.cpp
@@ -89,7 +89,7 @@ const gfx::UniformBlock UBOLocalBatched::LAYOUT = {
 const String                          UBOCamera::NAME       = "CCCamera";
 const gfx::DescriptorSetLayoutBinding UBOCamera::DESCRIPTOR = {
     UBOCamera::BINDING,
-    gfx::DescriptorType::UNIFORM_BUFFER,
+    gfx::DescriptorType::DYNAMIC_UNIFORM_BUFFER,
     1,
     gfx::ShaderStageFlagBit::ALL,
     {},

--- a/cocos/renderer/pipeline/PipelineUBO.h
+++ b/cocos/renderer/pipeline/PipelineUBO.h
@@ -52,10 +52,12 @@ public:
     void destroy();
     void updateGlobalUBO();
     void updateCameraUBO(const scene::Camera *camera);
+    void updateMultiCameraUBO(const vector<scene::Camera*> &cameras);
     void updateShadowUBO(const scene::Camera *camera);
     void updateShadowUBOLight(const scene::Light *light);
     void updateShadowUBORange(uint offset, const Mat4 *data);
     void destroyShadowFrameBuffers();
+    uint getCameraUBOOffset(scene::Camera *camera) const;
 
 private:
     RenderPipeline *_pipeline = nullptr;
@@ -67,6 +69,8 @@ private:
 
     std::vector<gfx::Buffer *> _ubos;
     void                       initCombineSignY();
+    std::vector<std::byte>     _cameraUBOs;
+    std::map<scene::Camera *, uint>_cameraUBOOffsetMap;
 };
 
 } // namespace pipeline

--- a/cocos/renderer/pipeline/deferred/DeferredPipeline.cpp
+++ b/cocos/renderer/pipeline/deferred/DeferredPipeline.cpp
@@ -129,10 +129,10 @@ bool DeferredPipeline::activate() {
 void DeferredPipeline::render(const vector<scene::Camera *> &cameras) {
     _commandBuffers[0]->begin();
     _pipelineUBO->updateGlobalUBO();
-
+    _pipelineUBO->updateMultiCameraUBO(cameras);
     for (auto *camera : cameras) {
         sceneCulling(this, camera);
-        _pipelineUBO->updateCameraUBO(camera);
+        //_pipelineUBO->updateCameraUBO(camera);
         for (auto *const flow : _flows) {
             flow->render(camera);
         }

--- a/cocos/renderer/pipeline/deferred/GbufferStage.cpp
+++ b/cocos/renderer/pipeline/deferred/GbufferStage.cpp
@@ -155,7 +155,7 @@ void GbufferStage::render(scene::Camera *camera) {
     auto *      renderPass   = framebuffer->getRenderPass();
 
     cmdBuff->beginRenderPass(renderPass, framebuffer, _renderArea, _clearColors, camera->clearDepth, camera->clearStencil);
-    cmdBuff->bindDescriptorSet(globalSet, _pipeline->getDescriptorSet());
+    cmdBuff->bindDescriptorSet(globalSet, _pipeline->getDescriptorSet(), {_pipeline->getPipelineUBO()->getCameraUBOOffset(camera)});
 
     _renderQueues[0]->recordCommandBuffer(_device, renderPass, cmdBuff);
     _instancedQueue->recordCommandBuffer(_device, renderPass, cmdBuff);

--- a/cocos/renderer/pipeline/deferred/LightingStage.cpp
+++ b/cocos/renderer/pipeline/deferred/LightingStage.cpp
@@ -355,7 +355,7 @@ void LightingStage::render(scene::Camera *camera) {
     cmdBuff->beginRenderPass(renderPass, frameBuffer, renderArea, &clearColor,
                              camera->clearDepth, camera->clearStencil);
 
-    cmdBuff->bindDescriptorSet(static_cast<uint>(SetIndex::GLOBAL), pipeline->getDescriptorSet());
+    cmdBuff->bindDescriptorSet(static_cast<uint>(SetIndex::GLOBAL), pipeline->getDescriptorSet(), {_pipeline->getPipelineUBO()->getCameraUBOOffset(camera)});
 
     // get pso and draw quad
     scene::Pass *pass   = sceneData->getSharedData()->deferredLightPass;

--- a/cocos/renderer/pipeline/deferred/PostprocessStage.cpp
+++ b/cocos/renderer/pipeline/deferred/PostprocessStage.cpp
@@ -104,7 +104,7 @@ void PostprocessStage::render(scene::Camera *camera) {
     gfx::RenderPass * rp            = !colorTextures.empty() && colorTextures[0] ? fb->getRenderPass() : pp->getOrCreateRenderPass(static_cast<gfx::ClearFlags>(camera->clearFlag));
 
     cmdBf->beginRenderPass(rp, fb, renderArea, _clearColors, camera->clearDepth, camera->clearStencil);
-    cmdBf->bindDescriptorSet(static_cast<uint>(SetIndex::GLOBAL), pp->getDescriptorSet());
+    cmdBf->bindDescriptorSet(static_cast<uint>(SetIndex::GLOBAL), pp->getDescriptorSet(), {_pipeline->getPipelineUBO()->getCameraUBOOffset(camera)});
 
     // post proces
     auto *const  sceneData     = _pipeline->getPipelineSceneData();

--- a/cocos/renderer/pipeline/forward/ForwardPipeline.cpp
+++ b/cocos/renderer/pipeline/forward/ForwardPipeline.cpp
@@ -123,12 +123,11 @@ bool ForwardPipeline::activate() {
 
 
 void ForwardPipeline::render(const vector<scene::Camera *> &cameras) {
-    
     _commandBuffers[0]->begin();
     _pipelineUBO->updateGlobalUBO();
+    _pipelineUBO->updateMultiCameraUBO(cameras);
     for (auto *camera : cameras) {
         sceneCulling(this, camera);
-        _pipelineUBO->updateCameraUBO(camera);
         for (auto *const flow : _flows) {
             flow->render(camera);
         }

--- a/cocos/renderer/pipeline/forward/ForwardStage.cpp
+++ b/cocos/renderer/pipeline/forward/ForwardStage.cpp
@@ -178,7 +178,7 @@ void ForwardStage::render(scene::Camera *camera) {
     auto *renderPass = !colorTextures.empty() && colorTextures[0] ? framebuffer->getRenderPass() : pipeline->getOrCreateRenderPass(static_cast<gfx::ClearFlagBit>(camera->clearFlag));
 
     cmdBuff->beginRenderPass(renderPass, framebuffer, _renderArea, _clearColors, camera->clearDepth, camera->clearStencil);
-    cmdBuff->bindDescriptorSet(globalSet, _pipeline->getDescriptorSet());
+    cmdBuff->bindDescriptorSet(globalSet, _pipeline->getDescriptorSet(), {_pipeline->getPipelineUBO()->getCameraUBOOffset(camera)});
 
     _renderQueues[0]->recordCommandBuffer(_device, renderPass, cmdBuff);
     _instancedQueue->recordCommandBuffer(_device, renderPass, cmdBuff);

--- a/cocos/renderer/pipeline/shadow/ShadowStage.cpp
+++ b/cocos/renderer/pipeline/shadow/ShadowStage.cpp
@@ -80,7 +80,7 @@ void ShadowStage::render(scene::Camera *camera) {
 
     cmdBuffer->beginRenderPass(renderPass, _framebuffer, _renderArea,
                                _clearColors, camera->clearDepth, camera->clearStencil);
-    cmdBuffer->bindDescriptorSet(globalSet, _pipeline->getDescriptorSet());
+    cmdBuffer->bindDescriptorSet(globalSet, _pipeline->getDescriptorSet(), {_pipeline->getPipelineUBO()->getCameraUBOOffset(camera)});
     _additiveShadowQueue->recordCommandBuffer(_device, renderPass, cmdBuffer);
 
     cmdBuffer->endRenderPass();


### PR DESCRIPTION
1. GlobalUBO直接使用Buffer::update来更新数据
2. CameraUBO安装相机个数分配一个大的Buffer,每个相机对应Buffer的片段，绑定的时候用DynamicOffset指定Buffer偏移量

@YunHsiao 