### PR TITLE
修复启动页面拖动窗口Vulkan Device Lost

### DIFF
--- a/cocos/renderer/gfx-agent/DeviceAgent.cpp
+++ b/cocos/renderer/gfx-agent/DeviceAgent.cpp
@@ -136,6 +136,7 @@ void DeviceAgent::acquire() {
         {
             actor->acquire();
         });
+    _mainMessageQueue->kickAndWait();
 }
 
 void DeviceAgent::present() {


### PR DESCRIPTION
导致Vulkan崩溃原因： vkCmdBeginRenderPass需要指定一个RenderArea的Rect，如果指定的Rect超出FrameBuffer的范围会导致Device Lost。

导致Rect超出FrameBuffer范围的原因：
1. 启动页面的渲染是由typescript的splash-screen类驱动的（acquire和present)，代码写在frame方法里；
2. 这个方法首先会通过Device的getWidth和getHeight拿到Framebuffer的大小，然后调用typescript端的GFXAPI去渲染启动页面( acquire, beginRenderPass, draw, endRenderPass, present);
2. GFX API调用不是直接调到具体API，而是先走MessageQueue，最后通过Queue到GFX的线程上执行，有一个延迟的过程；
3. 窗口发生变化时，Vulkan这边的处理是在CVKDevice::acquire的时候检查VkSurface判断窗口大小是否变化，如果变化重新创建FrameBuffer，这个过程是发生在GFX线程上的；
4. 窗口发生变化后，typescript的代码使用的RenderArea Rect就是过时的数据。当窗口变小了，typescript用的过时的Rect就超出了FrameBuffer的范围，导致device lost。在Debug模式下是断言失败，Release模式下是后续的渲染无效。

改动：
只加了一行代码，目的是使得device.acquire的调用是同步的。不清楚这样改是否会导致其他问题。

@minggo @YunHsiao  @caryliu1999 