### PR TITLE
fix vulkan-backend crash on android

### DIFF
--- a/cocos/platform/android/jni/JniCocosActivity.cpp
+++ b/cocos/platform/android/jni/JniCocosActivity.cpp
@@ -142,7 +142,7 @@ void glThreadEntry() {
             std::this_thread::yield();
         }
 
-        if (game) {
+        if (game && cc::cocosApp.animating) {
             // Handle java events send by UI thread. Input events are handled here too.
             cc::JniHelper::callStaticVoidMethod("com.cocos.lib.CocosHelper",
                                                 "flushTasksOnGameThread");

--- a/cocos/renderer/gfx-agent/DeviceAgent.cpp
+++ b/cocos/renderer/gfx-agent/DeviceAgent.cpp
@@ -213,7 +213,6 @@ void DeviceAgent::acquireSurface(uintptr_t windowHandle) {
         {
             actor->acquireSurface(windowHandle);
         });
-    _mainMessageQueue->kickAndWait();
 }
 
 CommandBuffer *DeviceAgent::createCommandBuffer(const CommandBufferInfo &info, bool /*hasAgent*/) {

--- a/cocos/renderer/gfx-agent/DeviceAgent.cpp
+++ b/cocos/renderer/gfx-agent/DeviceAgent.cpp
@@ -202,6 +202,7 @@ void DeviceAgent::releaseSurface(uintptr_t windowHandle) {
         {
             actor->releaseSurface(windowHandle);
         });
+    _mainMessageQueue->kickAndWait();
 }
 
 void DeviceAgent::acquireSurface(uintptr_t windowHandle) {
@@ -212,6 +213,7 @@ void DeviceAgent::acquireSurface(uintptr_t windowHandle) {
         {
             actor->acquireSurface(windowHandle);
         });
+    _mainMessageQueue->kickAndWait();
 }
 
 CommandBuffer *DeviceAgent::createCommandBuffer(const CommandBufferInfo &info, bool /*hasAgent*/) {

--- a/cocos/renderer/gfx-vulkan/VKContext.cpp
+++ b/cocos/renderer/gfx-vulkan/VKContext.cpp
@@ -545,7 +545,7 @@ void CCVKContext::releaseSurface(uintptr_t /*windowHandle*/) {
         VK_CHECK(vkWaitForFences(device->gpuDevice()->vkDevice, fenceCount,
                                  device->gpuFencePool()->data(), VK_TRUE, DEFAULT_TIMEOUT));
     }
-    VK_CHECK(vkDeviceWaitIdle(device->_gpuDevice->vkDevice));
+    device->waitAllFences();
     device->destroySwapchain();
     device->_swapchainReady = false;
 

--- a/cocos/renderer/gfx-vulkan/VKContext.cpp
+++ b/cocos/renderer/gfx-vulkan/VKContext.cpp
@@ -545,7 +545,7 @@ void CCVKContext::releaseSurface(uintptr_t /*windowHandle*/) {
         VK_CHECK(vkWaitForFences(device->gpuDevice()->vkDevice, fenceCount,
                                  device->gpuFencePool()->data(), VK_TRUE, DEFAULT_TIMEOUT));
     }
-
+    VK_CHECK(vkDeviceWaitIdle(device->_gpuDevice->vkDevice));
     device->destroySwapchain();
     device->_swapchainReady = false;
 

--- a/cocos/renderer/gfx-vulkan/VKContext.cpp
+++ b/cocos/renderer/gfx-vulkan/VKContext.cpp
@@ -539,6 +539,7 @@ void CCVKContext::releaseSurface(uintptr_t /*windowHandle*/) {
     if (_gpuContext && _gpuContext->vkSurface == VK_NULL_HANDLE) return;
 
     CCVKDevice *device = CCVKDevice::getInstance();
+    device->waitAllFences();
     device->destroySwapchain();
     device->_swapchainReady = false;
 

--- a/cocos/renderer/gfx-vulkan/VKContext.cpp
+++ b/cocos/renderer/gfx-vulkan/VKContext.cpp
@@ -539,13 +539,6 @@ void CCVKContext::releaseSurface(uintptr_t /*windowHandle*/) {
     if (_gpuContext && _gpuContext->vkSurface == VK_NULL_HANDLE) return;
 
     CCVKDevice *device = CCVKDevice::getInstance();
-
-    uint fenceCount = device->gpuFencePool()->size();
-    if (fenceCount) {
-        VK_CHECK(vkWaitForFences(device->gpuDevice()->vkDevice, fenceCount,
-                                 device->gpuFencePool()->data(), VK_TRUE, DEFAULT_TIMEOUT));
-    }
-    device->waitAllFences();
     device->destroySwapchain();
     device->_swapchainReady = false;
 

--- a/cocos/renderer/gfx-vulkan/VKDevice.cpp
+++ b/cocos/renderer/gfx-vulkan/VKDevice.cpp
@@ -608,9 +608,9 @@ void CCVKDevice::waitAllFences() {
     }
     if(!fences.empty()) {
         VK_CHECK(vkWaitForFences(_gpuDevice->vkDevice, fences.size(), fences.data(), VK_TRUE, DEFAULT_TIMEOUT));
-    }
-    for(auto* fencePool : _gpuFencePools) {
-        fencePool->reset();
+        for(auto* fencePool : _gpuFencePools) {
+            fencePool->reset();
+        }
     }
 }
 

--- a/cocos/renderer/gfx-vulkan/VKDevice.cpp
+++ b/cocos/renderer/gfx-vulkan/VKDevice.cpp
@@ -807,7 +807,6 @@ bool CCVKDevice::checkSwapchainStatus() {
 
 void CCVKDevice::destroySwapchain() {
     if (_gpuSwapchain->vkSwapchain != VK_NULL_HANDLE) {
-        waitAllFences();
 
         _gpuSwapchain->swapchainImageAccessTypes.clear();
         _gpuSwapchain->depthStencilImageAccessTypes.clear();

--- a/cocos/renderer/gfx-vulkan/VKDevice.cpp
+++ b/cocos/renderer/gfx-vulkan/VKDevice.cpp
@@ -714,10 +714,12 @@ bool CCVKDevice::checkSwapchainStatus() {
 
     CC_LOG_INFO("Resizing surface: %dx%d, surface rotation: %d degrees", newWidth, newHeight, (uint)_transform * 90);
 
+    VK_CHECK(vkDeviceWaitIdle(_gpuDevice->vkDevice));
+
     VkSwapchainKHR vkSwapchain = VK_NULL_HANDLE;
     VK_CHECK(vkCreateSwapchainKHR(_gpuDevice->vkDevice, &context->swapchainCreateInfo, nullptr, &vkSwapchain));
 
-    VK_CHECK(vkDeviceWaitIdle(_gpuDevice->vkDevice));
+
 
     destroySwapchain();
 

--- a/cocos/renderer/gfx-vulkan/VKDevice.cpp
+++ b/cocos/renderer/gfx-vulkan/VKDevice.cpp
@@ -608,7 +608,7 @@ void CCVKDevice::waitAllFences() {
     for(auto* fencePool : _gpuFencePools) {
         fences.insert(fences.end(), fencePool->data(), fencePool->data() + fencePool->size());
     }
-    if(fences.size() > 0) {
+    if(!fences.empty()) {
         VK_CHECK(vkWaitForFences(_gpuDevice->vkDevice, fences.size(), fences.data(), VK_TRUE, DEFAULT_TIMEOUT));
     }
 }

--- a/cocos/renderer/gfx-vulkan/VKDevice.h
+++ b/cocos/renderer/gfx-vulkan/VKDevice.h
@@ -96,6 +96,7 @@ public:
     CCVKGPUFencePool *        gpuFencePool();
     CCVKGPURecycleBin *       gpuRecycleBin();
     CCVKGPUStagingBufferPool *gpuStagingBufferPool();
+    void                      waitAllFences();
 
 protected:
     static CCVKDevice *instance;


### PR DESCRIPTION
切换App或者转到后台，App会收到APP_CMD_TERM_WINDOW事件，这时候会调用Device的releaseSurface释放掉VkSurface和VkSwapchain。调试发现收到这个事件后，App仍然可能调用gfx的api，此时VkSurface和VkSwapchain已经释放掉了，所以导致了崩溃。

改动如下：
1. releaseSurface先调用vkDeviceWaitIdle再释放Swapchain和VkSurface；
2. releaseSurface和acquireSurface调用_mainMessageQueue->kickAndWait()强制和GFX线程同步
3. App切换到后台后停止tick循环，为了阻止释放Swapchain后继续调用gfx api；

不知道这个改动是否合适？
@minggo @YunHsiao 
