### PR TITLE
Fix urlopen error in download-deps.py caused by missing TSL 1.2 support

### DIFF
--- a/download-deps.py
+++ b/download-deps.py
@@ -304,6 +304,12 @@ def _check_python_version():
                "Download it here: https://www.python.org/" % (major_ver, sys.version_info[1]))
         return False
 
+    # To make sure TLS 1.2 is supported by python
+    if sys.version_info < (2, 7, 9):
+        print ("The python version is %d.%d.%d. Please install 2.7.9 or higher version of python 2.x\n"
+               "Download it here: https://www.python.org/" % (sys.version_info[0], sys.version_info[1], sys.version_info[2]))
+        return False
+
     return True
 
 


### PR DESCRIPTION
- **TSL 1.2** is only available for python **2.7.9 or later**, so when using the earlier version and trying to connect the severs (such as github)  which are using TSL 1.2 by using **urlopen** will lead an error:
![error](https://user-images.githubusercontent.com/3478925/125979612-013ef96d-1db2-43f2-a035-89718f3eb043.png)

- This fix added the python full version check after major version of 2.x validation.