### PR TITLE
Fix se::Value dose not accept unsigned int 64.

### DIFF
--- a/cocos/bindings/manual/jsb_cocos_manual.cpp
+++ b/cocos/bindings/manual/jsb_cocos_manual.cpp
@@ -642,7 +642,7 @@ static bool js_engine_FileUtils_listFilesRecursively(se::State &s) {
         for (uint i = 0; i < static_cast<uint>(arg1.size()); i++) {
             list->setArrayElement(i, se::Value(arg1[i]));
         }
-        list->setProperty("length", se::Value(arg1.size()));
+        list->setProperty("length", se::Value(static_cast<std::uint32_t>(arg1.size())));
         return true;
     }
     SE_REPORT_ERROR("wrong number of arguments: %d, was expecting %d", (int)argc, 2);


### PR DESCRIPTION
se::Value dose not accept unsigned int 64,  so cast to unsigned int32 for 64 bit build to solve a build error in 64 bit build.