### PR TITLE
Fix SetWindowLongPtr for native windows.

### DIFF
--- a/cocos/ui/edit-box/EditBox-win32.cpp
+++ b/cocos/ui/edit-box/EditBox-win32.cpp
@@ -183,8 +183,8 @@ void EditBox::show(const EditBox::ShowInfo &showInfo) {
             return;
         }
 
-        g_prevMainWindowProc = (WNDPROC)SetWindowLongPtr(parent, GWL_WNDPROC, (LONG_PTR)mainWindowProc);
-        g_prevEditWindowProc = (WNDPROC)SetWindowLongPtr(g_hwndEditBox, GWL_WNDPROC, (LONG_PTR)editWindowProc);
+        g_prevMainWindowProc = (WNDPROC)SetWindowLongPtr(parent, GWLP_WNDPROC, (LONG_PTR)mainWindowProc);
+        g_prevEditWindowProc = (WNDPROC)SetWindowLongPtr(g_hwndEditBox, GWLP_WNDPROC, (LONG_PTR)editWindowProc);
     }
 
     ::SendMessageW(g_hwndEditBox, EM_LIMITTEXT, showInfo.maxLength, 0);
@@ -205,8 +205,8 @@ void EditBox::show(const EditBox::ShowInfo &showInfo) {
 void EditBox::hide() {
     DestroyWindow(g_hwndEditBox);
 
-    SetWindowLongPtr(cc_get_application_view()->getWindowHandler(), GWL_WNDPROC, (LONG_PTR)g_prevMainWindowProc);
-    SetWindowLongPtr(g_hwndEditBox, GWL_WNDPROC, (LONG_PTR)g_prevEditWindowProc);
+    SetWindowLongPtr(cc_get_application_view()->getWindowHandler(), GWLP_WNDPROC, (LONG_PTR)g_prevMainWindowProc);
+    SetWindowLongPtr(g_hwndEditBox, GWLP_WNDPROC, (LONG_PTR)g_prevEditWindowProc);
     g_hwndEditBox = nullptr;
 }
 


### PR DESCRIPTION
- Fix a build error which is caused by passing wrong argument to Windows API.

- As per [MSDN](https://docs.microsoft.com/en-us/windows/win32/api/winuser/nf-winuser-setwindowlongptrw) document, the second argument of SetWindowLongPtr function dose not accept **GWL_WNDPROC** but **GWLP_WNDPROC**.  

- Generally, for Windows API   "LP" stands for long pointer,  "L" is stands for long (integer value). Thus:
  - SetWindowLong uses GWL_WNDPROC.
  - SetWindowLongPtr  uses GWLP_WNDPROC.