### PR TITLE
Add VRContext

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1900,6 +1900,12 @@ cocos_source_files(
                  extensions/ExtensionMacros.h
 )
 
+if(USE_VR)
+    cocos_source_files(
+        cocos/vr/VRContext.cpp cocos/vr/VRContext.h
+    )
+endif()
+
 list(APPEND COCOS2D_SOURCE_LIST ${CC_EXTERNAL_SOURCES})
 
 add_library(cocos2d ${COCOS2D_SOURCE_LIST})

--- a/cocos/vr/VRContext.cpp
+++ b/cocos/vr/VRContext.cpp
@@ -1,0 +1,26 @@
+/****************************************************************************
+ Copyright (c) 2017-2021 Xiamen Yaji Software Co., Ltd.
+
+ http://www.cocos.com
+
+ Permission is hereby granted, free of charge, to any person obtaining a copy
+ of this software and associated engine source code (the "Software"), a limited,
+ worldwide, royalty-free, non-assignable, revocable and non-exclusive license
+ to use Cocos Creator solely to develop games on your target platforms. You shall
+ not use Cocos Creator software for developing other software or tools that's
+ used for developing games. You are not granted to publish, distribute,
+ sublicense, and/or sell copies of Cocos Creator.
+
+ The software or tools in this License Agreement are licensed, not sold.
+ Xiamen Yaji Software Co., Ltd. reserves all rights not expressly granted to you.
+
+ THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ THE SOFTWARE.
+****************************************************************************/
+
+#include "VRContext.h"

--- a/cocos/vr/VRContext.h
+++ b/cocos/vr/VRContext.h
@@ -1,0 +1,46 @@
+/****************************************************************************
+ Copyright (c) 2017-2021 Xiamen Yaji Software Co., Ltd.
+
+ http://www.cocos.com
+
+ Permission is hereby granted, free of charge, to any person obtaining a copy
+ of this software and associated engine source code (the "Software"), a limited,
+ worldwide, royalty-free, non-assignable, revocable and non-exclusive license
+ to use Cocos Creator solely to develop games on your target platforms. You shall
+ not use Cocos Creator software for developing other software or tools that's
+ used for developing games. You are not granted to publish, distribute,
+ sublicense, and/or sell copies of Cocos Creator.
+
+ The software or tools in this License Agreement are licensed, not sold.
+ Xiamen Yaji Software Co., Ltd. reserves all rights not expressly granted to you.
+
+ THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ THE SOFTWARE.
+****************************************************************************/
+
+#pragma once
+
+#ifndef __CC_VR_H__
+#define __CC_VR_H__
+namespace cc {
+class VRContext{
+public:
+    VRContext() = default;
+    virtual ~VRContext() = default;
+    VRContext(const VRContext&) = delete;
+    VRContext& operator=(const VRContext&) = delete;
+    VRContext(VRContext&&) noexcept = default;
+    VRContext& operator=(VRContext&&) noexcept = default;
+
+    virtual void Initialize() = 0;
+private:
+};
+
+}
+
+#endif


### PR DESCRIPTION
添加VR相关的类，相关源代码添加在cocos/vr/文件夹下，然后通过cmake当中的cocos_source_files引入相关文件。需要的库文件添加在external当中。这么设计是否妥当？