### PR TITLE
fix command buffer agent

### DIFF
--- a/cocos/renderer/gfx-agent/BufferAgent.h
+++ b/cocos/renderer/gfx-agent/BufferAgent.h
@@ -42,7 +42,7 @@ public:
 
     void update(const void *buffer, uint size) override;
 
-    void update(const void *buffer, uint size, MessageQueue *mq);
+    static void getActorBuffer(const BufferAgent *buffer, MessageQueue *mq, uint size, uint8_t **pActorBuffer, bool *pNeedFreeing);
 
 private:
     void doInit(const BufferInfo &info) override;


### PR DESCRIPTION
`CommandBufferAgent.updateBuffer` should only invoke itself on actors, not cross invoking `BufferAgent.update` instead.

This will cause buffers to be unconditionally immediately updated, which is not what we want.