### PR TITLE
fix:when skelton data destory clean all data.

### DIFF
--- a/cocos/editor-support/spine-creator-support/SkeletonAnimation.cpp
+++ b/cocos/editor-support/spine-creator-support/SkeletonAnimation.cpp
@@ -118,7 +118,6 @@ SkeletonAnimation::~SkeletonAnimation() {
     _eventListener     = nullptr;
 
     if (_state) {
-        clearTracks();
         if (_ownsAnimationStateData) delete _state->getData();
         delete _state;
     }

--- a/cocos/editor-support/spine-creator-support/SkeletonDataMgr.cpp
+++ b/cocos/editor-support/spine-creator-support/SkeletonDataMgr.cpp
@@ -35,7 +35,7 @@ using namespace spine;
 
 namespace spine {
 
-class SkeletonDataInfo : public cc::Ref {
+class SkeletonDataInfo {
 public:
     SkeletonDataInfo() = default;
 
@@ -89,7 +89,6 @@ SkeletonData *SkeletonDataMgr::retainByUUID(const std::string &uuid) {
     if (dataIt == _dataMap.end()) {
         return nullptr;
     }
-    dataIt->second->retain();
     return dataIt->second->data;
 }
 
@@ -99,15 +98,12 @@ void SkeletonDataMgr::releaseByUUID(const std::string &uuid) {
         return;
     }
     SkeletonDataInfo *info = dataIt->second;
-    // If info reference count is 1, then info will be destroy.
-    if (info->getReferenceCount() == 1) {
-        _dataMap.erase(dataIt);
-        if (_destroyCallback) {
-            auto &texturesIndex = info->texturesIndex;
-            for (auto it = texturesIndex.begin(); it != texturesIndex.end(); it++) {
-                _destroyCallback(*it);
-            }
+    _dataMap.erase(dataIt);
+    if (_destroyCallback) {
+        auto &texturesIndex = info->texturesIndex;
+        for (auto it = texturesIndex.begin(); it != texturesIndex.end(); it++) {
+            _destroyCallback(*it);
         }
     }
-    info->release();
+    delete info;
 }

--- a/cocos/editor-support/spine-creator-support/SkeletonRenderer.cpp
+++ b/cocos/editor-support/spine-creator-support/SkeletonRenderer.cpp
@@ -156,7 +156,6 @@ SkeletonRenderer::~SkeletonRenderer() {
     if (_ownsSkeleton) delete _skeleton;
     if (_ownsAtlas && _atlas) delete _atlas;
     delete _attachmentLoader;
-    if (!_uuid.empty()) SkeletonDataMgr::getInstance()->releaseByUUID(_uuid);
     delete _clipper;
 
     if (_debugBuffer) {


### PR DESCRIPTION
previous version the info still exists in the data map,
this cause initializing skeleton failed second time.
[https://forum.cocos.org/t/topic/118416/14](https://forum.cocos.org/t/topic/118416/14)