### PR TITLE
fix:when skelton data destory clean all data.

### DIFF
--- a/cocos/editor-support/spine-creator-support/SkeletonAnimation.cpp
+++ b/cocos/editor-support/spine-creator-support/SkeletonAnimation.cpp
@@ -118,7 +118,6 @@ SkeletonAnimation::~SkeletonAnimation() {
     _eventListener     = nullptr;
 
     if (_state) {
-        clearTracks();
         if (_ownsAnimationStateData) delete _state->getData();
         delete _state;
     }

--- a/cocos/editor-support/spine-creator-support/SkeletonDataMgr.cpp
+++ b/cocos/editor-support/spine-creator-support/SkeletonDataMgr.cpp
@@ -100,7 +100,6 @@ void SkeletonDataMgr::releaseByUUID(const std::string &uuid) {
     SkeletonDataInfo *info = dataIt->second;
     _dataMap.erase(dataIt);
     if (_destroyCallback) {
-        auto &texturesIndex = info->texturesIndex;
         for (auto &item : info->texturesIndex) {
             _destroyCallback(item);
         }

--- a/cocos/editor-support/spine-creator-support/SkeletonDataMgr.cpp
+++ b/cocos/editor-support/spine-creator-support/SkeletonDataMgr.cpp
@@ -35,7 +35,7 @@ using namespace spine;
 
 namespace spine {
 
-class SkeletonDataInfo : public cc::Ref {
+class SkeletonDataInfo {
 public:
     SkeletonDataInfo() = default;
 
@@ -89,7 +89,6 @@ SkeletonData *SkeletonDataMgr::retainByUUID(const std::string &uuid) {
     if (dataIt == _dataMap.end()) {
         return nullptr;
     }
-    dataIt->second->retain();
     return dataIt->second->data;
 }
 
@@ -99,15 +98,12 @@ void SkeletonDataMgr::releaseByUUID(const std::string &uuid) {
         return;
     }
     SkeletonDataInfo *info = dataIt->second;
-    // If info reference count is 1, then info will be destroy.
-    if (info->getReferenceCount() == 1) {
-        _dataMap.erase(dataIt);
-        if (_destroyCallback) {
-            auto &texturesIndex = info->texturesIndex;
-            for (auto it = texturesIndex.begin(); it != texturesIndex.end(); it++) {
-                _destroyCallback(*it);
-            }
+    _dataMap.erase(dataIt);
+    if (_destroyCallback) {
+        auto &texturesIndex = info->texturesIndex;
+        for (auto it = texturesIndex.begin(); it != texturesIndex.end(); it++) {
+            _destroyCallback(*it);
         }
     }
-    info->release();
+    delete info;
 }

--- a/cocos/editor-support/spine-creator-support/SkeletonDataMgr.cpp
+++ b/cocos/editor-support/spine-creator-support/SkeletonDataMgr.cpp
@@ -64,7 +64,7 @@ public:
 
 } // namespace spine
 
-SkeletonDataMgr *SkeletonDataMgr::_instance = nullptr;
+SkeletonDataMgr *SkeletonDataMgr::instance = nullptr;
 
 bool SkeletonDataMgr::hasSkeletonData(const std::string &uuid) {
     auto it = _dataMap.find(uuid);

--- a/cocos/editor-support/spine-creator-support/SkeletonDataMgr.cpp
+++ b/cocos/editor-support/spine-creator-support/SkeletonDataMgr.cpp
@@ -31,7 +31,7 @@
 #include <algorithm>
 #include <vector>
 
-using namespace spine;
+using namespace spine; //NOLINT
 
 namespace spine {
 
@@ -76,7 +76,7 @@ void SkeletonDataMgr::setSkeletonData(const std::string &uuid, SkeletonData *dat
     if (it != _dataMap.end()) {
         releaseByUUID(uuid);
     }
-    SkeletonDataInfo *info = new SkeletonDataInfo();
+    auto *info = new SkeletonDataInfo();
     info->data = data;
     info->atlas = atlas;
     info->attachmentLoader = attachmentLoader;
@@ -101,8 +101,8 @@ void SkeletonDataMgr::releaseByUUID(const std::string &uuid) {
     _dataMap.erase(dataIt);
     if (_destroyCallback) {
         auto &texturesIndex = info->texturesIndex;
-        for (auto it = texturesIndex.begin(); it != texturesIndex.end(); it++) {
-            _destroyCallback(*it);
+        for (auto &item : info->texturesIndex) {
+            _destroyCallback(item);
         }
     }
     delete info;

--- a/cocos/editor-support/spine-creator-support/SkeletonDataMgr.h
+++ b/cocos/editor-support/spine-creator-support/SkeletonDataMgr.h
@@ -47,36 +47,38 @@ class SkeletonDataInfo;
 class SkeletonDataMgr {
 public:
     static SkeletonDataMgr *getInstance() {
-        if (_instance == nullptr) {
-            _instance = new SkeletonDataMgr();
+        if (instance == nullptr) {
+            instance = new SkeletonDataMgr();
         }
-        return _instance;
+        return instance;
     }
 
     static void destroyInstance() {
-        if (_instance) {
-            delete _instance;
-            _instance = nullptr;
+        if (instance) {
+            delete instance;
+            instance = nullptr;
         }
     }
 
-    SkeletonDataMgr() {}
+    SkeletonDataMgr() = default;
 
     virtual ~SkeletonDataMgr() {
-        _destroyCallback = NULL;
+        _destroyCallback = nullptr;
     }
     bool hasSkeletonData(const std::string &uuid);
     void setSkeletonData(const std::string &uuid, SkeletonData *data, Atlas *atlas, AttachmentLoader *attachmentLoader, const std::vector<int> &texturesIndex);
+    // equal to 'findByUUID'
     SkeletonData *retainByUUID(const std::string &uuid);
+    // equal to 'deleteByUUID'
     void releaseByUUID(const std::string &uuid);
 
-    typedef std::function<void(int)> destroyCallback;
+    using destroyCallback = std::function<void(int)>;
     void setDestroyCallback(destroyCallback callback) {
-        _destroyCallback = callback;
+        _destroyCallback = std::move(callback);
     }
 
 private:
-    static SkeletonDataMgr *_instance;
+    static SkeletonDataMgr* instance;
     destroyCallback _destroyCallback = nullptr;
     std::map<std::string, SkeletonDataInfo *> _dataMap;
 };

--- a/cocos/editor-support/spine-creator-support/SkeletonRenderer.cpp
+++ b/cocos/editor-support/spine-creator-support/SkeletonRenderer.cpp
@@ -156,7 +156,6 @@ SkeletonRenderer::~SkeletonRenderer() {
     if (_ownsSkeleton) delete _skeleton;
     if (_ownsAtlas && _atlas) delete _atlas;
     delete _attachmentLoader;
-    if (!_uuid.empty()) SkeletonDataMgr::getInstance()->releaseByUUID(_uuid);
     delete _clipper;
 
     if (_debugBuffer) {


### PR DESCRIPTION
engine pr: [https://github.com/cocos-creator/engine/pull/9139](https://github.com/cocos-creator/engine/pull/9139)
previous version the info still exists in the data map,
this cause initializing skeleton failed second time.

[https://forum.cocos.org/t/topic/118416/11](https://forum.cocos.org/t/topic/118416/11)