### PR TITLE
3.3 [bugfix] pause tick before recreate surface

### DIFF
--- a/cocos/platform/ohos/jni/JniCocosAbility.cpp
+++ b/cocos/platform/ohos/jni/JniCocosAbility.cpp
@@ -156,7 +156,7 @@ void glThreadEntry() {
             std::this_thread::yield();
         }
 
-        if (game) {
+        if (game && cc::cocosApp.animating) {
             // Handle java events send by UI thread. Input events are handled here too.
             cc::JniHelper::callStaticVoidMethod("com.cocos.lib.CocosHelper",
                                                 "flushTasksOnGameThread");


### PR DESCRIPTION
fix: https://github.com/cocos-creator/3d-tasks/issues/8276

在从后台切出 且 EGLSurface recreate 完成之前, 停止调用 tick 方法.  
 Android 在 https://github.com/cocos-creator/engine-native/pull/3700 修复