### PR TITLE
fix spotlight shadow matrix, lineardepth, packing mode, selfbias error (#8483)

### DIFF
--- a/cocos/renderer/pipeline/Define.h
+++ b/cocos/renderer/pipeline/Define.h
@@ -416,7 +416,10 @@ struct CC_DLL UBOShadow : public Object {
     static constexpr uint                        MAT_LIGHT_PLANE_PROJ_OFFSET                   = 0;
     static constexpr uint                        MAT_LIGHT_VIEW_OFFSET                         = MAT_LIGHT_PLANE_PROJ_OFFSET + 16;
     static constexpr uint                        MAT_LIGHT_VIEW_PROJ_OFFSET                    = UBOShadow::MAT_LIGHT_VIEW_OFFSET + 16;
-    static constexpr uint                        SHADOW_NEAR_FAR_LINEAR_SATURATION_INFO_OFFSET = UBOShadow::MAT_LIGHT_VIEW_PROJ_OFFSET + 16;
+    static constexpr uint                        SHADOW_INV_PROJ_DEPTH_INFO_OFFSET             = UBOShadow::MAT_LIGHT_VIEW_PROJ_OFFSET + 16;
+    static constexpr uint                        SHADOW_PROJ_DEPTH_INFO_OFFSET                 = UBOShadow::SHADOW_INV_PROJ_DEPTH_INFO_OFFSET + 4;
+    static constexpr uint                        SHADOW_PROJ_INFO_OFFSET                       = UBOShadow::SHADOW_PROJ_DEPTH_INFO_OFFSET + 4;
+    static constexpr uint                        SHADOW_NEAR_FAR_LINEAR_SATURATION_INFO_OFFSET = UBOShadow::SHADOW_PROJ_INFO_OFFSET + 4;
     static constexpr uint                        SHADOW_WIDTH_HEIGHT_PCF_BIAS_INFO_OFFSET      = UBOShadow::SHADOW_NEAR_FAR_LINEAR_SATURATION_INFO_OFFSET + 4;
     static constexpr uint                        SHADOW_LIGHT_PACKING_NBIAS_NULL_INFO_OFFSET   = UBOShadow::SHADOW_WIDTH_HEIGHT_PCF_BIAS_INFO_OFFSET + 4;
     static constexpr uint                        SHADOW_COLOR_OFFSET                           = UBOShadow::SHADOW_LIGHT_PACKING_NBIAS_NULL_INFO_OFFSET + 4;

--- a/cocos/renderer/pipeline/PipelineUBO.cpp
+++ b/cocos/renderer/pipeline/PipelineUBO.cpp
@@ -195,13 +195,14 @@ void PipelineUBO::updateShadowUBOView(const RenderPipeline *pipeline, std::array
 
                 farClamp = shadowInfo->farValue;
             }
-            memcpy(shadowUBO.data() + UBOShadow::MAT_LIGHT_VIEW_OFFSET, matShadowCamera.m, sizeof(matShadowCamera));
+            const auto matShadowView = matShadowCamera.getInversed();
 
-            const auto matShadowView  = matShadowCamera.getInversed();
             const auto projectionSinY = device->getCapabilities().clipSpaceSignY;
             Mat4::createOrthographicOffCenter(-x, x, -y, y, shadowInfo->nearValue, farClamp, device->getCapabilities().clipSpaceMinZ, projectionSinY, &matShadowViewProj);
-
+            Mat4  matShadowProj           = matShadowViewProj;
             matShadowViewProj.multiply(matShadowView);
+
+            memcpy(shadowUBO.data() + UBOShadow::MAT_LIGHT_VIEW_OFFSET, matShadowView.m, sizeof(matShadowView));
             memcpy(shadowUBO.data() + UBOShadow::MAT_LIGHT_VIEW_PROJ_OFFSET, matShadowViewProj.m, sizeof(matShadowViewProj));
 
             const float linear             = hFTexture ? 1.0F : 0.0F;
@@ -214,6 +215,12 @@ void PipelineUBO::updateShadowUBOView(const RenderPipeline *pipeline, std::array
             const float packing            = hFTexture ? 0.0F : 1.0F;
             float       shadowLPNNInfos[4] = {0.0F, packing, shadowInfo->normalBias, 0.0F};
             memcpy(shadowUBO.data() + UBOShadow::SHADOW_LIGHT_PACKING_NBIAS_NULL_INFO_OFFSET, &shadowLPNNInfos, sizeof(shadowLPNNInfos));
+
+            float shadowProjDepthInfos[4] = {matShadowProj.m[10], matShadowProj.m[14], matShadowProj.m[11], matShadowProj.m[15]};
+            memcpy(shadowUBO.data() + UBOShadow::SHADOW_PROJ_DEPTH_INFO_OFFSET, &shadowProjDepthInfos, sizeof(shadowProjDepthInfos));
+
+            float shadowProjInfos[4] = {matShadowProj.m[00], matShadowProj.m[05], 1.0F / matShadowProj.m[00], 1.0F / matShadowProj.m[05]};
+            memcpy(shadowUBO.data() + UBOShadow::SHADOW_PROJ_INFO_OFFSET, &shadowProjInfos, sizeof(shadowProjInfos));
         } else if (mainLight && shadowInfo->shadowType == scene::ShadowType::PLANAR) {
             updateDirLight(shadowInfo, mainLight, &shadowUBO);
         }
@@ -230,7 +237,7 @@ void PipelineUBO::updateShadowUBOLightView(const RenderPipeline *pipeline, std::
     auto *      sphere     = sceneData->getSphere();
     auto &      shadowUBO  = *bufferView;
     const bool  hFTexture  = supportsHalfFloatTexture(device);
-    const float linear     = hFTexture ? 1.0F : 0.0F;
+    const float linear     = 0.0F;
     const float packing    = hFTexture ? 0.0F : 1.0F;
     switch (light->getType()) {
         case scene::LightType::DIRECTIONAL: {
@@ -258,9 +265,9 @@ void PipelineUBO::updateShadowUBOLightView(const RenderPipeline *pipeline, std::
 
                 farClamp = shadowInfo->farValue;
             }
-            memcpy(shadowUBO.data() + UBOShadow::MAT_LIGHT_VIEW_OFFSET, matShadowCamera.m, sizeof(matShadowCamera));
+            const auto matShadowView = matShadowCamera.getInversed();
+            memcpy(shadowUBO.data() + UBOShadow::MAT_LIGHT_VIEW_OFFSET, matShadowView.m, sizeof(matShadowView));
 
-            const auto matShadowView  = matShadowCamera.getInversed();
             const auto projectionSinY = device->getCapabilities().clipSpaceSignY;
             Mat4::createOrthographicOffCenter(-x, x, -y, y, shadowInfo->nearValue, farClamp, device->getCapabilities().clipSpaceMinZ, projectionSinY, &matShadowViewProj);
 
@@ -276,9 +283,9 @@ void PipelineUBO::updateShadowUBOLightView(const RenderPipeline *pipeline, std::
         case scene::LightType::SPOT: {
             const auto *spotLight       = static_cast<const scene::SpotLight *>(light);
             const auto &matShadowCamera = spotLight->getNode()->getWorldMatrix();
-            memcpy(shadowUBO.data() + UBOShadow::MAT_LIGHT_VIEW_OFFSET, matShadowCamera.m, sizeof(matShadowCamera));
+            const auto  matShadowView   = matShadowCamera.getInversed();
+            memcpy(shadowUBO.data() + UBOShadow::MAT_LIGHT_VIEW_OFFSET, matShadowView.m, sizeof(matShadowView));
 
-            const auto matShadowView = matShadowCamera.getInversed();
             cc::Mat4::createPerspective(spotLight->getSpotAngle(), spotLight->getAspect(), 0.001F, spotLight->getRange(), &matShadowViewProj);
 
             matShadowViewProj.multiply(matShadowView);

--- a/cocos/renderer/pipeline/PipelineUBO.cpp
+++ b/cocos/renderer/pipeline/PipelineUBO.cpp
@@ -198,8 +198,9 @@ void PipelineUBO::updateShadowUBOView(const RenderPipeline *pipeline, std::array
             const auto matShadowView = matShadowCamera.getInversed();
 
             const auto projectionSinY = device->getCapabilities().clipSpaceSignY;
-            Mat4::createOrthographicOffCenter(-x, x, -y, y, shadowInfo->nearValue, farClamp, device->getCapabilities().clipSpaceMinZ, projectionSinY, &matShadowViewProj);
-            Mat4  matShadowProj           = matShadowViewProj;
+            Mat4 matShadowProj;
+            Mat4::createOrthographicOffCenter(-x, x, -y, y, shadowInfo->nearValue, farClamp, device->getCapabilities().clipSpaceMinZ, projectionSinY, &matShadowProj);
+            matShadowViewProj = matShadowProj;
             matShadowViewProj.multiply(matShadowView);
 
             memcpy(shadowUBO.data() + UBOShadow::MAT_LIGHT_VIEW_OFFSET, matShadowView.m, sizeof(matShadowView));

--- a/cocos/renderer/pipeline/RenderAdditiveLightQueue.cpp
+++ b/cocos/renderer/pipeline/RenderAdditiveLightQueue.cpp
@@ -311,7 +311,7 @@ void RenderAdditiveLightQueue::updateLightDescriptorSet(const scene::Camera *cam
     const auto *const   scene              = camera->scene;
     auto *              device             = gfx::Device::getInstance();
     const bool          hFTexture          = supportsHalfFloatTexture(device);
-    const float         linear             = hFTexture ? 1.0F : 0.0F;
+    const float         linear             = 0.0F;
     const float         packing            = hFTexture ? 0.0F : 1.0F;
     const scene::Light *mainLight          = scene->getMainLight();
 
@@ -346,15 +346,16 @@ void RenderAdditiveLightQueue::updateLightDescriptorSet(const scene::Camera *cam
                 }
 
                 const auto &matShadowCamera = light->getNode()->getWorldMatrix();
-                memcpy(_shadowUBO.data() + UBOShadow::MAT_LIGHT_VIEW_OFFSET, matShadowCamera.m, sizeof(matShadowCamera));
-
-                const auto matShadowView = matShadowCamera.getInversed();
+                const auto  matShadowView   = matShadowCamera.getInversed();
 
                 cc::Mat4 matShadowViewProj;
                 cc::Mat4::createPerspective(spotLight->getSpotAngle(), spotLight->getAspect(), 0.001F, spotLight->getRange(), &matShadowViewProj);
+                cc::Mat4 matShadowProj = matShadowViewProj, matShadowInvProj = matShadowProj;
+                matShadowInvProj.inverse();
 
                 matShadowViewProj.multiply(matShadowView);
 
+                memcpy(_shadowUBO.data() + UBOShadow::MAT_LIGHT_VIEW_OFFSET, matShadowView.m, sizeof(matShadowView));
                 memcpy(_shadowUBO.data() + UBOShadow::MAT_LIGHT_VIEW_PROJ_OFFSET, matShadowViewProj.m, sizeof(matShadowViewProj));
 
                 // shadow info
@@ -366,6 +367,15 @@ void RenderAdditiveLightQueue::updateLightDescriptorSet(const scene::Camera *cam
 
                 float shadowLPNNInfos[4] = {1.0F, packing, shadowInfo->normalBias, 0.0F};
                 memcpy(_shadowUBO.data() + UBOShadow::SHADOW_LIGHT_PACKING_NBIAS_NULL_INFO_OFFSET, &shadowLPNNInfos, sizeof(float) * 4);
+
+                float shadowInvProjDepthInfos[4] = {matShadowInvProj.m[10], matShadowInvProj.m[14], matShadowInvProj.m[11], matShadowInvProj.m[15]};
+                memcpy(_shadowUBO.data() + UBOShadow::SHADOW_INV_PROJ_DEPTH_INFO_OFFSET, &shadowInvProjDepthInfos, sizeof(shadowInvProjDepthInfos));
+
+                float shadowProjDepthInfos[4] = {matShadowProj.m[10], matShadowProj.m[14], matShadowProj.m[11], matShadowProj.m[15]};
+                memcpy(_shadowUBO.data() + UBOShadow::SHADOW_PROJ_DEPTH_INFO_OFFSET, &shadowProjDepthInfos, sizeof(shadowProjDepthInfos));
+
+                float shadowProjInfos[4] = {matShadowProj.m[00], matShadowProj.m[05], 1.0F / matShadowProj.m[00], 1.0F / matShadowProj.m[05]};
+                memcpy(_shadowUBO.data() + UBOShadow::SHADOW_PROJ_INFO_OFFSET, &shadowProjInfos, sizeof(shadowProjInfos));
 
                 // Spot light sampler binding
                 const auto &shadowFramebufferMap = sceneData->getShadowFramebufferMap();

--- a/cocos/renderer/pipeline/RenderAdditiveLightQueue.cpp
+++ b/cocos/renderer/pipeline/RenderAdditiveLightQueue.cpp
@@ -350,7 +350,8 @@ void RenderAdditiveLightQueue::updateLightDescriptorSet(const scene::Camera *cam
 
                 cc::Mat4 matShadowViewProj;
                 cc::Mat4::createPerspective(spotLight->getSpotAngle(), spotLight->getAspect(), 0.001F, spotLight->getRange(), &matShadowViewProj);
-                cc::Mat4 matShadowProj = matShadowViewProj, matShadowInvProj = matShadowProj;
+                cc::Mat4 matShadowProj = matShadowViewProj;
+                cc::Mat4 matShadowInvProj = matShadowProj;
                 matShadowInvProj.inverse();
 
                 matShadowViewProj.multiply(matShadowView);

--- a/cocos/renderer/pipeline/RenderAdditiveLightQueue.cpp
+++ b/cocos/renderer/pipeline/RenderAdditiveLightQueue.cpp
@@ -348,9 +348,9 @@ void RenderAdditiveLightQueue::updateLightDescriptorSet(const scene::Camera *cam
                 const auto &matShadowCamera = light->getNode()->getWorldMatrix();
                 const auto  matShadowView   = matShadowCamera.getInversed();
 
-                cc::Mat4 matShadowViewProj;
-                cc::Mat4::createPerspective(spotLight->getSpotAngle(), spotLight->getAspect(), 0.001F, spotLight->getRange(), &matShadowViewProj);
-                cc::Mat4 matShadowProj = matShadowViewProj;
+                cc::Mat4 matShadowProj;
+                cc::Mat4::createPerspective(spotLight->getSpotAngle(), spotLight->getAspect(), 0.001F, spotLight->getRange(), &matShadowProj);
+                cc::Mat4 matShadowViewProj = matShadowProj;
                 cc::Mat4 matShadowInvProj = matShadowProj;
                 matShadowInvProj.inverse();
 

--- a/cocos/renderer/pipeline/shadow/ShadowFlow.cpp
+++ b/cocos/renderer/pipeline/shadow/ShadowFlow.cpp
@@ -120,7 +120,7 @@ void ShadowFlow::resizeShadowMap(scene::Shadow **shadowInfo) {
     auto *     device    = gfx::Device::getInstance();
     const auto width     = static_cast<uint>((*shadowInfo)->size.x);
     const auto height    = static_cast<uint>((*shadowInfo)->size.y);
-    const auto format    = supportsHalfFloatTexture(device) ? gfx::Format::R16F : gfx::Format::RGBA8;
+    const auto format    = supportsHalfFloatTexture(device) ? gfx::Format::R32F : gfx::Format::RGBA8;
 
     for (const auto &pair : sceneData->getShadowFramebufferMap()) {
         gfx::Framebuffer *framebuffer = pair.second;
@@ -174,7 +174,7 @@ void ShadowFlow::initShadowFrameBuffer(RenderPipeline *pipeline, const scene::Li
     const auto  shadowMapSize = shadowInfo->size;
     const auto  width         = static_cast<uint>(shadowMapSize.x);
     const auto  height        = static_cast<uint>(shadowMapSize.y);
-    const auto  format        = supportsHalfFloatTexture(device) ? gfx::Format::R16F : gfx::Format::RGBA8;
+    const auto  format        = supportsHalfFloatTexture(device) ? gfx::Format::R32F : gfx::Format::RGBA8;
     
     const gfx::ColorAttachment colorAttachment = {
         format,


### PR DESCRIPTION
 - Fix spotlight shadow bugs for range, angel, linear mode, packing mode, etc...
 - Change shadow bias to world space unit, make dirlight and spotlight shadow adjust more easily
 - Spotlight Soft / 2X Shadow as same as DirLight