### PR TITLE
fix command buffer validator cache

### DIFF
--- a/cocos/renderer/gfx-validator/CommandBufferValidator.cpp
+++ b/cocos/renderer/gfx-validator/CommandBufferValidator.cpp
@@ -76,6 +76,7 @@ void CommandBufferValidator::begin(RenderPass *renderPass, uint subpass, Framebu
     _commandsFlushed  = false;
 
     _recorder.clear();
+    _curStates.descriptorSets.assign(_curStates.descriptorSets.size(), nullptr);
 
     /////////// execute ///////////
 


### PR DESCRIPTION
Descriptor set cache has to be cleared in case we're holding dangling pointers