### PR TITLE
fix fg exec storage

### DIFF
--- a/cocos/bindings/auto/jsb_gfx_auto.cpp
+++ b/cocos/bindings/auto/jsb_gfx_auto.cpp
@@ -15541,9 +15541,9 @@ bool js_register_gfx_GFXObject(se::Object* obj) // NOLINT(readability-identifier
 {
     auto* cls = se::Class::create("GFXObject", obj, nullptr, _SE(js_gfx_GFXObject_constructor));
 
-    cls->defineProperty("typedID", _SE(js_gfx_GFXObject_getTypedID), nullptr);
-    cls->defineProperty("objectID", _SE(js_gfx_GFXObject_getObjectID), nullptr);
     cls->defineProperty("objectType", _SE(js_gfx_GFXObject_getObjectType), nullptr);
+    cls->defineProperty("objectID", _SE(js_gfx_GFXObject_getObjectID), nullptr);
+    cls->defineProperty("typedID", _SE(js_gfx_GFXObject_getTypedID), nullptr);
     cls->defineFinalizeFunction(_SE(js_cc_gfx_GFXObject_finalize));
     cls->install();
     JSBClassType::registerClass<cc::gfx::GFXObject>(cls);
@@ -15773,12 +15773,12 @@ bool js_register_gfx_Buffer(se::Object* obj) // NOLINT(readability-identifier-na
 {
     auto* cls = se::Class::create("Buffer", obj, __jsb_cc_gfx_GFXObject_proto, _SE(js_gfx_Buffer_constructor));
 
-    cls->defineProperty("count", _SE(js_gfx_Buffer_getCount), nullptr);
+    cls->defineProperty("usage", _SE(js_gfx_Buffer_getUsage), nullptr);
     cls->defineProperty("memUsage", _SE(js_gfx_Buffer_getMemUsage), nullptr);
     cls->defineProperty("stride", _SE(js_gfx_Buffer_getStride), nullptr);
-    cls->defineProperty("flags", _SE(js_gfx_Buffer_getFlags), nullptr);
-    cls->defineProperty("usage", _SE(js_gfx_Buffer_getUsage), nullptr);
+    cls->defineProperty("count", _SE(js_gfx_Buffer_getCount), nullptr);
     cls->defineProperty("size", _SE(js_gfx_Buffer_getSize), nullptr);
+    cls->defineProperty("flags", _SE(js_gfx_Buffer_getFlags), nullptr);
     cls->defineFunction("destroy", _SE(js_gfx_Buffer_destroy));
     cls->defineFunction("isBufferView", _SE(js_gfx_Buffer_isBufferView));
     cls->defineFunction("resize", _SE(js_gfx_Buffer_resize));
@@ -16106,19 +16106,19 @@ bool js_register_gfx_InputAssembler(se::Object* obj) // NOLINT(readability-ident
 {
     auto* cls = se::Class::create("InputAssembler", obj, __jsb_cc_gfx_GFXObject_proto, _SE(js_gfx_InputAssembler_constructor));
 
-    cls->defineProperty("instanceCount", nullptr, _SE(js_gfx_InputAssembler_setInstanceCount));
     cls->defineProperty("vertexBuffers", _SE(js_gfx_InputAssembler_getVertexBuffers), nullptr);
-    cls->defineProperty("attributesHash", _SE(js_gfx_InputAssembler_getAttributesHash), nullptr);
-    cls->defineProperty("firstInstance", nullptr, _SE(js_gfx_InputAssembler_setFirstInstance));
-    cls->defineProperty("vertexCount", nullptr, _SE(js_gfx_InputAssembler_setVertexCount));
-    cls->defineProperty("drawInfo", _SE(js_gfx_InputAssembler_getDrawInfo), nullptr);
-    cls->defineProperty("indexBuffer", _SE(js_gfx_InputAssembler_getIndexBuffer), nullptr);
-    cls->defineProperty("vertexOffset", nullptr, _SE(js_gfx_InputAssembler_setVertexOffset));
     cls->defineProperty("attributes", _SE(js_gfx_InputAssembler_getAttributes), nullptr);
+    cls->defineProperty("indexBuffer", _SE(js_gfx_InputAssembler_getIndexBuffer), nullptr);
+    cls->defineProperty("indirectBuffer", _SE(js_gfx_InputAssembler_getIndirectBuffer), nullptr);
+    cls->defineProperty("attributesHash", _SE(js_gfx_InputAssembler_getAttributesHash), nullptr);
+    cls->defineProperty("drawInfo", _SE(js_gfx_InputAssembler_getDrawInfo), nullptr);
+    cls->defineProperty("vertexCount", nullptr, _SE(js_gfx_InputAssembler_setVertexCount));
+    cls->defineProperty("firstVertex", nullptr, _SE(js_gfx_InputAssembler_setFirstVertex));
     cls->defineProperty("indexCount", nullptr, _SE(js_gfx_InputAssembler_setIndexCount));
     cls->defineProperty("firstIndex", nullptr, _SE(js_gfx_InputAssembler_setFirstIndex));
-    cls->defineProperty("indirectBuffer", _SE(js_gfx_InputAssembler_getIndirectBuffer), nullptr);
-    cls->defineProperty("firstVertex", nullptr, _SE(js_gfx_InputAssembler_setFirstVertex));
+    cls->defineProperty("vertexOffset", nullptr, _SE(js_gfx_InputAssembler_setVertexOffset));
+    cls->defineProperty("instanceCount", nullptr, _SE(js_gfx_InputAssembler_setInstanceCount));
+    cls->defineProperty("firstInstance", nullptr, _SE(js_gfx_InputAssembler_setFirstInstance));
     cls->defineFunction("destroy", _SE(js_gfx_InputAssembler_destroy));
     cls->defineFunction("initialize", _SE(js_gfx_InputAssembler_initialize));
     cls->defineFinalizeFunction(_SE(js_cc_gfx_InputAssembler_finalize));
@@ -17734,8 +17734,8 @@ bool js_register_gfx_Framebuffer(se::Object* obj) // NOLINT(readability-identifi
 {
     auto* cls = se::Class::create("Framebuffer", obj, __jsb_cc_gfx_GFXObject_proto, _SE(js_gfx_Framebuffer_constructor));
 
-    cls->defineProperty("colorTextures", _SE(js_gfx_Framebuffer_getColorTextures), nullptr);
     cls->defineProperty("renderPass", _SE(js_gfx_Framebuffer_getRenderPass), nullptr);
+    cls->defineProperty("colorTextures", _SE(js_gfx_Framebuffer_getColorTextures), nullptr);
     cls->defineProperty("depthStencilTexture", _SE(js_gfx_Framebuffer_getDepthStencilTexture), nullptr);
     cls->defineFunction("destroy", _SE(js_gfx_Framebuffer_destroy));
     cls->defineFunction("initialize", _SE(js_gfx_Framebuffer_initialize));
@@ -18104,14 +18104,14 @@ bool js_register_gfx_PipelineState(se::Object* obj) // NOLINT(readability-identi
 {
     auto* cls = se::Class::create("PipelineState", obj, __jsb_cc_gfx_GFXObject_proto, _SE(js_gfx_PipelineState_constructor));
 
-    cls->defineProperty("primitive", _SE(js_gfx_PipelineState_getPrimitive), nullptr);
-    cls->defineProperty("rasterizerState", _SE(js_gfx_PipelineState_getRasterizerState), nullptr);
     cls->defineProperty("shader", _SE(js_gfx_PipelineState_getShader), nullptr);
+    cls->defineProperty("primitive", _SE(js_gfx_PipelineState_getPrimitive), nullptr);
+    cls->defineProperty("bindPoint", _SE(js_gfx_PipelineState_getBindPoint), nullptr);
+    cls->defineProperty("inputState", _SE(js_gfx_PipelineState_getInputState), nullptr);
+    cls->defineProperty("rasterizerState", _SE(js_gfx_PipelineState_getRasterizerState), nullptr);
+    cls->defineProperty("depthStencilState", _SE(js_gfx_PipelineState_getDepthStencilState), nullptr);
     cls->defineProperty("blendState", _SE(js_gfx_PipelineState_getBlendState), nullptr);
     cls->defineProperty("renderPass", _SE(js_gfx_PipelineState_getRenderPass), nullptr);
-    cls->defineProperty("inputState", _SE(js_gfx_PipelineState_getInputState), nullptr);
-    cls->defineProperty("bindPoint", _SE(js_gfx_PipelineState_getBindPoint), nullptr);
-    cls->defineProperty("depthStencilState", _SE(js_gfx_PipelineState_getDepthStencilState), nullptr);
     cls->defineFunction("destroy", _SE(js_gfx_PipelineState_destroy));
     cls->defineFunction("getDynamicStates", _SE(js_gfx_PipelineState_getDynamicStates));
     cls->defineFunction("getPipelineLayout", _SE(js_gfx_PipelineState_getPipelineLayout));
@@ -18697,10 +18697,10 @@ bool js_register_gfx_Shader(se::Object* obj) // NOLINT(readability-identifier-na
 {
     auto* cls = se::Class::create("Shader", obj, __jsb_cc_gfx_GFXObject_proto, _SE(js_gfx_Shader_constructor));
 
-    cls->defineProperty("attributes", _SE(js_gfx_Shader_getAttributes), nullptr);
-    cls->defineProperty("stages", _SE(js_gfx_Shader_getStages), nullptr);
-    cls->defineProperty("blocks", _SE(js_gfx_Shader_getBlocks), nullptr);
     cls->defineProperty("name", _SE(js_gfx_Shader_getName), nullptr);
+    cls->defineProperty("stages", _SE(js_gfx_Shader_getStages), nullptr);
+    cls->defineProperty("attributes", _SE(js_gfx_Shader_getAttributes), nullptr);
+    cls->defineProperty("blocks", _SE(js_gfx_Shader_getBlocks), nullptr);
     cls->defineProperty("samplers", _SE(js_gfx_Shader_getSamplers), nullptr);
     cls->defineFunction("destroy", _SE(js_gfx_Shader_destroy));
     cls->defineFunction("getBuffers", _SE(js_gfx_Shader_getBuffers));
@@ -18974,12 +18974,12 @@ bool js_register_gfx_Texture(se::Object* obj) // NOLINT(readability-identifier-n
     auto* cls = se::Class::create("Texture", obj, __jsb_cc_gfx_GFXObject_proto, _SE(js_gfx_Texture_constructor));
 
     cls->defineProperty("info", _SE(js_gfx_Texture_getInfo), nullptr);
-    cls->defineProperty("hash", _SE(js_gfx_Texture_getHash), nullptr);
-    cls->defineProperty("format", _SE(js_gfx_Texture_getFormat), nullptr);
-    cls->defineProperty("height", _SE(js_gfx_Texture_getHeight), nullptr);
-    cls->defineProperty("width", _SE(js_gfx_Texture_getWidth), nullptr);
     cls->defineProperty("viewInfo", _SE(js_gfx_Texture_getViewInfo), nullptr);
+    cls->defineProperty("width", _SE(js_gfx_Texture_getWidth), nullptr);
+    cls->defineProperty("height", _SE(js_gfx_Texture_getHeight), nullptr);
+    cls->defineProperty("format", _SE(js_gfx_Texture_getFormat), nullptr);
     cls->defineProperty("size", _SE(js_gfx_Texture_getSize), nullptr);
+    cls->defineProperty("hash", _SE(js_gfx_Texture_getHash), nullptr);
     cls->defineFunction("destroy", _SE(js_gfx_Texture_destroy));
     cls->defineFunction("isTextureView", _SE(js_gfx_Texture_isTextureView));
     cls->defineFunction("resize", _SE(js_gfx_Texture_resize));
@@ -19290,10 +19290,10 @@ bool js_register_gfx_Swapchain(se::Object* obj) // NOLINT(readability-identifier
     auto* cls = se::Class::create("Swapchain", obj, __jsb_cc_gfx_GFXObject_proto, _SE(js_gfx_Swapchain_constructor));
 
     cls->defineProperty("width", _SE(js_gfx_Swapchain_getWidth), nullptr);
-    cls->defineProperty("surfaceTransform", _SE(js_gfx_Swapchain_getSurfaceTransform), nullptr);
-    cls->defineProperty("depthStencilTexture", _SE(js_gfx_Swapchain_getDepthStencilTexture), nullptr);
-    cls->defineProperty("colorTexture", _SE(js_gfx_Swapchain_getColorTexture), nullptr);
     cls->defineProperty("height", _SE(js_gfx_Swapchain_getHeight), nullptr);
+    cls->defineProperty("surfaceTransform", _SE(js_gfx_Swapchain_getSurfaceTransform), nullptr);
+    cls->defineProperty("colorTexture", _SE(js_gfx_Swapchain_getColorTexture), nullptr);
+    cls->defineProperty("depthStencilTexture", _SE(js_gfx_Swapchain_getDepthStencilTexture), nullptr);
     cls->defineFunction("createSurface", _SE(js_gfx_Swapchain_createSurface));
     cls->defineFunction("destroy", _SE(js_gfx_Swapchain_destroy));
     cls->defineFunction("destroySurface", _SE(js_gfx_Swapchain_destroySurface));
@@ -20265,17 +20265,17 @@ bool js_register_gfx_Device(se::Object* obj) // NOLINT(readability-identifier-na
 {
     auto* cls = se::Class::create("Device", obj, nullptr, nullptr);
 
+    cls->defineProperty("gfxAPI", _SE(js_gfx_Device_getGfxAPI), nullptr);
     cls->defineProperty("deviceName", _SE(js_gfx_Device_getDeviceName), nullptr);
+    cls->defineProperty("memoryStatus", _SE(js_gfx_Device_getMemoryStatus), nullptr);
+    cls->defineProperty("queue", _SE(js_gfx_Device_getQueue), nullptr);
+    cls->defineProperty("commandBuffer", _SE(js_gfx_Device_getCommandBuffer), nullptr);
+    cls->defineProperty("renderer", _SE(js_gfx_Device_getRenderer), nullptr);
     cls->defineProperty("vendor", _SE(js_gfx_Device_getVendor), nullptr);
     cls->defineProperty("numDrawCalls", _SE(js_gfx_Device_getNumDrawCalls), nullptr);
-    cls->defineProperty("memoryStatus", _SE(js_gfx_Device_getMemoryStatus), nullptr);
-    cls->defineProperty("gfxAPI", _SE(js_gfx_Device_getGfxAPI), nullptr);
-    cls->defineProperty("capabilities", _SE(js_gfx_Device_getCapabilities), nullptr);
-    cls->defineProperty("numTris", _SE(js_gfx_Device_getNumTris), nullptr);
-    cls->defineProperty("queue", _SE(js_gfx_Device_getQueue), nullptr);
-    cls->defineProperty("renderer", _SE(js_gfx_Device_getRenderer), nullptr);
-    cls->defineProperty("commandBuffer", _SE(js_gfx_Device_getCommandBuffer), nullptr);
     cls->defineProperty("numInstances", _SE(js_gfx_Device_getNumInstances), nullptr);
+    cls->defineProperty("numTris", _SE(js_gfx_Device_getNumTris), nullptr);
+    cls->defineProperty("capabilities", _SE(js_gfx_Device_getCapabilities), nullptr);
     cls->defineFunction("acquire", _SE(js_gfx_Device_acquire));
     cls->defineFunction("bindingMappingInfo", _SE(js_gfx_Device_bindingMappingInfo));
     cls->defineFunction("createCommandBuffer", _SE(js_gfx_Device_createCommandBuffer));
@@ -20309,19 +20309,6 @@ bool js_register_gfx_Device(se::Object* obj) // NOLINT(readability-identifier-na
 se::Object* __jsb_cc_gfx_DeviceManager_proto = nullptr;
 se::Class* __jsb_cc_gfx_DeviceManager_class = nullptr;
 
-static bool js_gfx_DeviceManager_destroy(se::State& s) // NOLINT(readability-identifier-naming)
-{
-    const auto& args = s.args();
-    size_t argc = args.size();
-    if (argc == 0) {
-        cc::gfx::DeviceManager::destroy();
-        return true;
-    }
-    SE_REPORT_ERROR("wrong number of arguments: %d, was expecting %d", (int)argc, 0);
-    return false;
-}
-SE_BIND_FUNC(js_gfx_DeviceManager_destroy)
-
 static bool js_gfx_DeviceManager_create(se::State& s) // NOLINT(readability-identifier-naming)
 {
     const auto& args = s.args();
@@ -20341,6 +20328,19 @@ static bool js_gfx_DeviceManager_create(se::State& s) // NOLINT(readability-iden
     return false;
 }
 SE_BIND_FUNC(js_gfx_DeviceManager_create)
+
+static bool js_gfx_DeviceManager_destroy(se::State& s) // NOLINT(readability-identifier-naming)
+{
+    const auto& args = s.args();
+    size_t argc = args.size();
+    if (argc == 0) {
+        cc::gfx::DeviceManager::destroy();
+        return true;
+    }
+    SE_REPORT_ERROR("wrong number of arguments: %d, was expecting %d", (int)argc, 0);
+    return false;
+}
+SE_BIND_FUNC(js_gfx_DeviceManager_destroy)
 
 static bool js_gfx_DeviceManager_addSurfaceEventListener(se::State& s) // NOLINT(readability-identifier-naming)
 {
@@ -20373,8 +20373,8 @@ bool js_register_gfx_DeviceManager(se::Object* obj) // NOLINT(readability-identi
 {
     auto* cls = se::Class::create("DeviceManager", obj, nullptr, nullptr);
 
-    cls->defineStaticFunction("destroy", _SE(js_gfx_DeviceManager_destroy));
     cls->defineStaticFunction("create", _SE(js_gfx_DeviceManager_create));
+    cls->defineStaticFunction("destroy", _SE(js_gfx_DeviceManager_destroy));
     cls->defineStaticFunction("addSurfaceEventListener", _SE(js_gfx_DeviceManager_addSurfaceEventListener));
     cls->defineFinalizeFunction(_SE(js_cc_gfx_DeviceManager_finalize));
     cls->install();
@@ -20398,81 +20398,81 @@ bool register_all_gfx(se::Object* obj)
     }
     se::Object* ns = nsVal.toObject();
 
+    js_register_gfx_Size(ns);
+    js_register_gfx_DeviceCaps(ns);
+    js_register_gfx_Offset(ns);
+    js_register_gfx_Rect(ns);
+    js_register_gfx_Extent(ns);
+    js_register_gfx_TextureSubresLayers(ns);
+    js_register_gfx_TextureSubresRange(ns);
+    js_register_gfx_TextureCopy(ns);
+    js_register_gfx_TextureBlit(ns);
+    js_register_gfx_BufferTextureCopy(ns);
+    js_register_gfx_Viewport(ns);
+    js_register_gfx_Color(ns);
+    js_register_gfx_BindingMappingInfo(ns);
     js_register_gfx_SwapchainInfo(ns);
+    js_register_gfx_DeviceInfo(ns);
+    js_register_gfx_BufferInfo(ns);
+    js_register_gfx_BufferViewInfo(ns);
+    js_register_gfx_DrawInfo(ns);
+    js_register_gfx_DispatchInfo(ns);
+    js_register_gfx_IndirectBuffer(ns);
+    js_register_gfx_TextureInfo(ns);
+    js_register_gfx_TextureViewInfo(ns);
+    js_register_gfx_SamplerInfo(ns);
+    js_register_gfx_Uniform(ns);
+    js_register_gfx_UniformBlock(ns);
+    js_register_gfx_UniformSamplerTexture(ns);
+    js_register_gfx_UniformSampler(ns);
+    js_register_gfx_UniformTexture(ns);
+    js_register_gfx_UniformStorageImage(ns);
+    js_register_gfx_UniformStorageBuffer(ns);
+    js_register_gfx_UniformInputAttachment(ns);
+    js_register_gfx_ShaderStage(ns);
+    js_register_gfx_Attribute(ns);
+    js_register_gfx_ShaderInfo(ns);
+    js_register_gfx_InputAssemblerInfo(ns);
+    js_register_gfx_ColorAttachment(ns);
+    js_register_gfx_DepthStencilAttachment(ns);
     js_register_gfx_SubpassInfo(ns);
+    js_register_gfx_SubpassDependency(ns);
+    js_register_gfx_RenderPassInfo(ns);
+    js_register_gfx_GlobalBarrierInfo(ns);
+    js_register_gfx_TextureBarrierInfo(ns);
+    js_register_gfx_FramebufferInfo(ns);
+    js_register_gfx_DescriptorSetLayoutBinding(ns);
+    js_register_gfx_DescriptorSetLayoutInfo(ns);
+    js_register_gfx_DescriptorSetInfo(ns);
+    js_register_gfx_PipelineLayoutInfo(ns);
+    js_register_gfx_InputState(ns);
+    js_register_gfx_RasterizerState(ns);
+    js_register_gfx_DepthStencilState(ns);
+    js_register_gfx_BlendTarget(ns);
+    js_register_gfx_BlendState(ns);
+    js_register_gfx_PipelineStateInfo(ns);
+    js_register_gfx_CommandBufferInfo(ns);
+    js_register_gfx_QueueInfo(ns);
+    js_register_gfx_MemoryStatus(ns);
     js_register_gfx_GFXObject(ns);
     js_register_gfx_Buffer(ns);
+    js_register_gfx_InputAssembler(ns);
+    js_register_gfx_CommandBuffer(ns);
+    js_register_gfx_DescriptorSet(ns);
+    js_register_gfx_DescriptorSetLayout(ns);
+    js_register_gfx_Framebuffer(ns);
+    js_register_gfx_PipelineLayout(ns);
+    js_register_gfx_PipelineState(ns);
+    js_register_gfx_Queue(ns);
+    js_register_gfx_RenderPass(ns);
+    js_register_gfx_Shader(ns);
+    js_register_gfx_Texture(ns);
+    js_register_gfx_Swapchain(ns);
+    js_register_gfx_GlobalBarrier(ns);
+    js_register_gfx_Sampler(ns);
     js_register_gfx_TextureBarrier(ns);
     js_register_gfx_Device(ns);
-    js_register_gfx_Texture(ns);
-    js_register_gfx_Uniform(ns);
-    js_register_gfx_DescriptorSet(ns);
-    js_register_gfx_BlendTarget(ns);
-    js_register_gfx_DispatchInfo(ns);
-    js_register_gfx_PipelineState(ns);
-    js_register_gfx_TextureBarrierInfo(ns);
-    js_register_gfx_PipelineLayout(ns);
-    js_register_gfx_Sampler(ns);
-    js_register_gfx_InputAssembler(ns);
-    js_register_gfx_RenderPass(ns);
-    js_register_gfx_BufferInfo(ns);
-    js_register_gfx_SamplerInfo(ns);
-    js_register_gfx_QueueInfo(ns);
-    js_register_gfx_UniformStorageBuffer(ns);
-    js_register_gfx_SubpassDependency(ns);
-    js_register_gfx_UniformSamplerTexture(ns);
-    js_register_gfx_BufferTextureCopy(ns);
-    js_register_gfx_PipelineLayoutInfo(ns);
-    js_register_gfx_InputAssemblerInfo(ns);
-    js_register_gfx_TextureBlit(ns);
-    js_register_gfx_TextureInfo(ns);
-    js_register_gfx_GlobalBarrierInfo(ns);
-    js_register_gfx_RenderPassInfo(ns);
-    js_register_gfx_Extent(ns);
-    js_register_gfx_Offset(ns);
-    js_register_gfx_CommandBuffer(ns);
-    js_register_gfx_Framebuffer(ns);
-    js_register_gfx_Viewport(ns);
-    js_register_gfx_TextureSubresLayers(ns);
-    js_register_gfx_BufferViewInfo(ns);
-    js_register_gfx_UniformInputAttachment(ns);
-    js_register_gfx_UniformSampler(ns);
-    js_register_gfx_ShaderInfo(ns);
-    js_register_gfx_PipelineStateInfo(ns);
-    js_register_gfx_Shader(ns);
-    js_register_gfx_BlendState(ns);
-    js_register_gfx_GlobalBarrier(ns);
-    js_register_gfx_DescriptorSetInfo(ns);
-    js_register_gfx_DescriptorSetLayoutInfo(ns);
-    js_register_gfx_DrawInfo(ns);
-    js_register_gfx_InputState(ns);
-    js_register_gfx_CommandBufferInfo(ns);
-    js_register_gfx_UniformStorageImage(ns);
-    js_register_gfx_UniformBlock(ns);
-    js_register_gfx_DepthStencilAttachment(ns);
-    js_register_gfx_TextureSubresRange(ns);
-    js_register_gfx_TextureViewInfo(ns);
-    js_register_gfx_Queue(ns);
-    js_register_gfx_ColorAttachment(ns);
-    js_register_gfx_RasterizerState(ns);
     js_register_gfx_DeviceManager(ns);
-    js_register_gfx_Color(ns);
-    js_register_gfx_Attribute(ns);
-    js_register_gfx_MemoryStatus(ns);
-    js_register_gfx_DeviceInfo(ns);
-    js_register_gfx_Swapchain(ns);
-    js_register_gfx_DepthStencilState(ns);
-    js_register_gfx_BindingMappingInfo(ns);
-    js_register_gfx_FramebufferInfo(ns);
-    js_register_gfx_DeviceCaps(ns);
-    js_register_gfx_Rect(ns);
-    js_register_gfx_ShaderStage(ns);
-    js_register_gfx_DescriptorSetLayoutBinding(ns);
-    js_register_gfx_UniformTexture(ns);
-    js_register_gfx_DescriptorSetLayout(ns);
-    js_register_gfx_TextureCopy(ns);
-    js_register_gfx_IndirectBuffer(ns);
-    js_register_gfx_Size(ns);
     return true;
 }
 

--- a/cocos/bindings/auto/jsb_gfx_auto.h
+++ b/cocos/bindings/auto/jsb_gfx_auto.h
@@ -849,7 +849,7 @@ bool js_register_cc_gfx_DeviceManager(se::Object* obj);
 bool register_all_gfx(se::Object* obj);
 
 JSB_REGISTER_OBJECT_TYPE(cc::gfx::DeviceManager);
-SE_DECLARE_FUNC(js_gfx_DeviceManager_destroy);
 SE_DECLARE_FUNC(js_gfx_DeviceManager_create);
+SE_DECLARE_FUNC(js_gfx_DeviceManager_destroy);
 SE_DECLARE_FUNC(js_gfx_DeviceManager_addSurfaceEventListener);
 

--- a/cocos/bindings/auto/jsb_pipeline_auto.cpp
+++ b/cocos/bindings/auto/jsb_pipeline_auto.cpp
@@ -2033,19 +2033,6 @@ static bool js_pipeline_InstancedBuffer_setDynamicOffset(se::State& s) // NOLINT
 }
 SE_BIND_FUNC(js_pipeline_InstancedBuffer_setDynamicOffset)
 
-static bool js_pipeline_InstancedBuffer_destroyInstancedBuffer(se::State& s) // NOLINT(readability-identifier-naming)
-{
-    const auto& args = s.args();
-    size_t argc = args.size();
-    if (argc == 0) {
-        cc::pipeline::InstancedBuffer::destroyInstancedBuffer();
-        return true;
-    }
-    SE_REPORT_ERROR("wrong number of arguments: %d, was expecting %d", (int)argc, 0);
-    return false;
-}
-SE_BIND_FUNC(js_pipeline_InstancedBuffer_destroyInstancedBuffer)
-
 static bool js_pipeline_InstancedBuffer_get(se::State& s) // NOLINT(readability-identifier-naming)
 {
     CC_UNUSED bool ok = true;
@@ -2082,6 +2069,19 @@ static bool js_pipeline_InstancedBuffer_get(se::State& s) // NOLINT(readability-
     return false;
 }
 SE_BIND_FUNC(js_pipeline_InstancedBuffer_get)
+
+static bool js_pipeline_InstancedBuffer_destroyInstancedBuffer(se::State& s) // NOLINT(readability-identifier-naming)
+{
+    const auto& args = s.args();
+    size_t argc = args.size();
+    if (argc == 0) {
+        cc::pipeline::InstancedBuffer::destroyInstancedBuffer();
+        return true;
+    }
+    SE_REPORT_ERROR("wrong number of arguments: %d, was expecting %d", (int)argc, 0);
+    return false;
+}
+SE_BIND_FUNC(js_pipeline_InstancedBuffer_destroyInstancedBuffer)
 
 SE_DECLARE_FINALIZE_FUNC(js_cc_pipeline_InstancedBuffer_finalize)
 
@@ -2120,8 +2120,8 @@ bool js_register_pipeline_InstancedBuffer(se::Object* obj) // NOLINT(readability
 
     cls->defineFunction("destroy", _SE(js_pipeline_InstancedBuffer_destroy));
     cls->defineFunction("setDynamicOffset", _SE(js_pipeline_InstancedBuffer_setDynamicOffset));
-    cls->defineStaticFunction("destroyInstancedBuffer", _SE(js_pipeline_InstancedBuffer_destroyInstancedBuffer));
     cls->defineStaticFunction("get", _SE(js_pipeline_InstancedBuffer_get));
+    cls->defineStaticFunction("destroyInstancedBuffer", _SE(js_pipeline_InstancedBuffer_destroyInstancedBuffer));
     cls->defineFinalizeFunction(_SE(js_cc_pipeline_InstancedBuffer_finalize));
     cls->install();
     JSBClassType::registerClass<cc::pipeline::InstancedBuffer>(cls);
@@ -2342,42 +2342,6 @@ bool js_register_pipeline_MainFlow(se::Object* obj) // NOLINT(readability-identi
 se::Object* __jsb_cc_pipeline_GbufferStage_proto = nullptr;
 se::Class* __jsb_cc_pipeline_GbufferStage_class = nullptr;
 
-static bool js_pipeline_GbufferStage_dispenseRenderObject2Queues(se::State& s) // NOLINT(readability-identifier-naming)
-{
-    auto* cobj = SE_THIS_OBJECT<cc::pipeline::GbufferStage>(s);
-    SE_PRECONDITION2(cobj, false, "js_pipeline_GbufferStage_dispenseRenderObject2Queues : Invalid Native Object");
-    const auto& args = s.args();
-    size_t argc = args.size();
-    if (argc == 0) {
-        cobj->dispenseRenderObject2Queues();
-        return true;
-    }
-    SE_REPORT_ERROR("wrong number of arguments: %d, was expecting %d", (int)argc, 0);
-    return false;
-}
-SE_BIND_FUNC(js_pipeline_GbufferStage_dispenseRenderObject2Queues)
-
-static bool js_pipeline_GbufferStage_recordCommands(se::State& s) // NOLINT(readability-identifier-naming)
-{
-    auto* cobj = SE_THIS_OBJECT<cc::pipeline::GbufferStage>(s);
-    SE_PRECONDITION2(cobj, false, "js_pipeline_GbufferStage_recordCommands : Invalid Native Object");
-    const auto& args = s.args();
-    size_t argc = args.size();
-    CC_UNUSED bool ok = true;
-    if (argc == 2) {
-        HolderType<cc::pipeline::DeferredPipeline*, false> arg0 = {};
-        HolderType<cc::gfx::RenderPass*, false> arg1 = {};
-        ok &= sevalue_to_native(args[0], &arg0, s.thisObject());
-        ok &= sevalue_to_native(args[1], &arg1, s.thisObject());
-        SE_PRECONDITION2(ok, false, "js_pipeline_GbufferStage_recordCommands : Error processing arguments");
-        cobj->recordCommands(arg0.value(), arg1.value());
-        return true;
-    }
-    SE_REPORT_ERROR("wrong number of arguments: %d, was expecting %d", (int)argc, 2);
-    return false;
-}
-SE_BIND_FUNC(js_pipeline_GbufferStage_recordCommands)
-
 static bool js_pipeline_GbufferStage_getInitializeInfo(se::State& s) // NOLINT(readability-identifier-naming)
 {
     const auto& args = s.args();
@@ -2425,8 +2389,6 @@ bool js_register_pipeline_GbufferStage(se::Object* obj) // NOLINT(readability-id
 {
     auto* cls = se::Class::create("GbufferStage", obj, __jsb_cc_pipeline_RenderStage_proto, _SE(js_pipeline_GbufferStage_constructor));
 
-    cls->defineFunction("dispenseRenderObject2Queues", _SE(js_pipeline_GbufferStage_dispenseRenderObject2Queues));
-    cls->defineFunction("recordCommands", _SE(js_pipeline_GbufferStage_recordCommands));
     cls->defineStaticFunction("getInitializeInfo", _SE(js_pipeline_GbufferStage_getInitializeInfo));
     cls->defineFinalizeFunction(_SE(js_cc_pipeline_GbufferStage_finalize));
     cls->install();
@@ -2573,24 +2535,24 @@ bool register_all_pipeline(se::Object* obj)
     se::Object* ns = nsVal.toObject();
 
     js_register_pipeline_RenderQueueDesc(ns);
-    js_register_pipeline_RenderFlow(ns);
-    js_register_pipeline_RenderStage(ns);
-    js_register_pipeline_LightingStage(ns);
-    js_register_pipeline_RenderPipeline(ns);
-    js_register_pipeline_RenderStageInfo(ns);
-    js_register_pipeline_ForwardPipeline(ns);
-    js_register_pipeline_GbufferStage(ns);
-    js_register_pipeline_RenderPipelineInfo(ns);
-    js_register_pipeline_ForwardStage(ns);
-    js_register_pipeline_ShadowStage(ns);
     js_register_pipeline_GlobalDSManager(ns);
+    js_register_pipeline_RenderPipelineInfo(ns);
+    js_register_pipeline_RenderPipeline(ns);
+    js_register_pipeline_ForwardPipeline(ns);
     js_register_pipeline_RenderFlowInfo(ns);
-    js_register_pipeline_PostprocessStage(ns);
+    js_register_pipeline_RenderFlow(ns);
     js_register_pipeline_ForwardFlow(ns);
+    js_register_pipeline_RenderStageInfo(ns);
+    js_register_pipeline_RenderStage(ns);
+    js_register_pipeline_ForwardStage(ns);
+    js_register_pipeline_ShadowFlow(ns);
+    js_register_pipeline_ShadowStage(ns);
     js_register_pipeline_InstancedBuffer(ns);
     js_register_pipeline_DeferredPipeline(ns);
     js_register_pipeline_MainFlow(ns);
-    js_register_pipeline_ShadowFlow(ns);
+    js_register_pipeline_GbufferStage(ns);
+    js_register_pipeline_LightingStage(ns);
+    js_register_pipeline_PostprocessStage(ns);
     return true;
 }
 

--- a/cocos/bindings/auto/jsb_pipeline_auto.h
+++ b/cocos/bindings/auto/jsb_pipeline_auto.h
@@ -185,8 +185,8 @@ bool register_all_pipeline(se::Object* obj);
 JSB_REGISTER_OBJECT_TYPE(cc::pipeline::InstancedBuffer);
 SE_DECLARE_FUNC(js_pipeline_InstancedBuffer_destroy);
 SE_DECLARE_FUNC(js_pipeline_InstancedBuffer_setDynamicOffset);
-SE_DECLARE_FUNC(js_pipeline_InstancedBuffer_destroyInstancedBuffer);
 SE_DECLARE_FUNC(js_pipeline_InstancedBuffer_get);
+SE_DECLARE_FUNC(js_pipeline_InstancedBuffer_destroyInstancedBuffer);
 SE_DECLARE_FUNC(js_pipeline_InstancedBuffer_InstancedBuffer);
 
 extern se::Object* __jsb_cc_pipeline_DeferredPipeline_proto;
@@ -220,8 +220,6 @@ bool js_register_cc_pipeline_GbufferStage(se::Object* obj);
 bool register_all_pipeline(se::Object* obj);
 
 JSB_REGISTER_OBJECT_TYPE(cc::pipeline::GbufferStage);
-SE_DECLARE_FUNC(js_pipeline_GbufferStage_dispenseRenderObject2Queues);
-SE_DECLARE_FUNC(js_pipeline_GbufferStage_recordCommands);
 SE_DECLARE_FUNC(js_pipeline_GbufferStage_getInitializeInfo);
 SE_DECLARE_FUNC(js_pipeline_GbufferStage_GbufferStage);
 

--- a/cocos/renderer/frame-graph/CallbackPass.h
+++ b/cocos/renderer/frame-graph/CallbackPass.h
@@ -32,21 +32,25 @@ namespace framegraph {
 
 class Executable {
 public:
-    Executable() noexcept          = default;
-    virtual ~Executable()          = default;
-    Executable(const Executable &) = delete;
-    Executable(Executable &&)      = delete;
+    Executable() noexcept              = default;
+    virtual ~Executable()              = default;
+    Executable(const Executable &)     = delete;
+    Executable(Executable &&) noexcept = delete;
     Executable &operator=(const Executable &) = delete;
-    Executable &operator=(Executable &&) = delete;
+    Executable &operator=(Executable &&) noexcept = delete;
 
-    virtual void execute(const DevicePassResourceTable &resourceTable) noexcept = 0;
+    virtual void execute(const DevicePassResourceTable &resourceTable) const noexcept = 0;
 };
 
-template <typename Data, typename ExecuteMethod>
+template <typename Data, typename ExecuteMethodType>
 class CallbackPass final : public Executable {
 public:
+    using ExecuteMethod = std::remove_reference_t<ExecuteMethodType>;
+
+    explicit CallbackPass(ExecuteMethod &execute) noexcept;
     explicit CallbackPass(ExecuteMethod &&execute) noexcept;
-    void               execute(const DevicePassResourceTable &resourceTable) noexcept override;
+
+    void               execute(const DevicePassResourceTable &resourceTable) const noexcept override;
     inline const Data &getData() const noexcept { return _data; }
     inline Data &      getData() noexcept { return _data; }
 
@@ -58,13 +62,19 @@ private:
 //////////////////////////////////////////////////////////////////////////
 
 template <typename Data, typename ExecuteMethod>
+CallbackPass<Data, ExecuteMethod>::CallbackPass(ExecuteMethod &execute) noexcept
+: Executable(),
+  _execute(execute) {
+}
+
+template <typename Data, typename ExecuteMethod>
 CallbackPass<Data, ExecuteMethod>::CallbackPass(ExecuteMethod &&execute) noexcept
 : Executable(),
   _execute(execute) {
 }
 
 template <typename Data, typename ExecuteMethod>
-void CallbackPass<Data, ExecuteMethod>::execute(const DevicePassResourceTable &resourceTable) noexcept {
+void CallbackPass<Data, ExecuteMethod>::execute(const DevicePassResourceTable &resourceTable) const noexcept {
     _execute(_data, resourceTable);
 }
 

--- a/cocos/renderer/frame-graph/FrameGraph.cpp
+++ b/cocos/renderer/frame-graph/FrameGraph.cpp
@@ -57,7 +57,7 @@ const char *FrameGraph::handleToString(const StringHandle &handle) noexcept {
 
 void FrameGraph::present(const TextureHandle &input, gfx::Texture *target) {
     static const StringHandle PRESENT_PASS = FrameGraph::stringToHandle("Present");
-    const ResourceNode &      resourceNode   = getResourceNode(input);
+    const ResourceNode &      resourceNode = getResourceNode(input);
     CC_ASSERT(resourceNode.writer);
 
     struct PassDataPresent {

--- a/cocos/renderer/frame-graph/FrameGraph.h
+++ b/cocos/renderer/frame-graph/FrameGraph.h
@@ -62,7 +62,7 @@ public:
     static void gc(uint32_t unusedFrameCount = 30) noexcept;
 
     template <typename Data, typename SetupMethod, typename ExecuteMethod>
-    CallbackPass<Data, ExecuteMethod> const &addPass(PassInsertPoint insertPoint, const StringHandle &name, SetupMethod setup, ExecuteMethod &&execute) noexcept;
+    const CallbackPass<Data, ExecuteMethod> &addPass(PassInsertPoint insertPoint, const StringHandle &name, SetupMethod setup, ExecuteMethod &&execute) noexcept;
 
     template <typename ResourceType>
     TypedHandle<ResourceType> create(const StringHandle &name, const typename ResourceType::Descriptor &desc) noexcept;

--- a/cocos/renderer/gfx-agent/SwapchainAgent.h
+++ b/cocos/renderer/gfx-agent/SwapchainAgent.h
@@ -40,6 +40,8 @@ public:
 
     // TO BE REMOVED
     SurfaceTransform getSurfaceTransform() const override { return _actor->getSurfaceTransform(); }
+    uint32_t getWidth() const override { return _actor->getWidth(); }
+    uint32_t getHeight() const override { return _actor->getHeight(); }
 
 protected:
     void doInit(const SwapchainInfo &info) override;

--- a/cocos/renderer/gfx-base/GFXSwapchain.cpp
+++ b/cocos/renderer/gfx-base/GFXSwapchain.cpp
@@ -52,12 +52,18 @@ void Swapchain::destroy() {
 }
 
 void Swapchain::resize(uint32_t width, uint32_t height, SurfaceTransform transform) {
-    if (width != _colorTexture->getWidth() || height != _colorTexture->getHeight()) {
+    if (width != _colorTexture->getWidth() || height != _colorTexture->getHeight() || transform != _transform) {
         doResize(width, height, transform);
 
-        _colorTexture->_info.width = _depthStencilTexture->_info.width = width;
-        _colorTexture->_info.height = _depthStencilTexture->_info.height = height;
-        if (isPreRotationEnabled()) _transform = transform;
+        // if (isPreRotationEnabled()) {
+        //     if (toNumber(transform) % 2) {
+        //         std::swap(width, height);
+        //     }
+        //     _transform = transform;
+        // }
+
+        // _colorTexture->_info.width = _depthStencilTexture->_info.width = width;
+        // _colorTexture->_info.height = _depthStencilTexture->_info.height = height;
     }
 }
 

--- a/cocos/renderer/gfx-base/GFXSwapchain.h
+++ b/cocos/renderer/gfx-base/GFXSwapchain.h
@@ -49,14 +49,14 @@ public:
     inline Texture *getColorTexture() const { return _colorTexture; }
     inline Texture *getDepthStencilTexture() const { return _depthStencilTexture; }
 
-    inline uint32_t getWidth() const { return _colorTexture->getWidth(); }
-    inline uint32_t getHeight() const { return _colorTexture->getHeight(); }
-
     virtual bool isPreRotationEnabled() { return _preRotationEnabled; }
 
     // TO BE REMOVED
     inline void resize(uint32_t width, uint32_t height) { resize(width, height, SurfaceTransform::IDENTITY); }
+    // TO BE INLINED
     virtual SurfaceTransform getSurfaceTransform() const { return _transform; }
+    virtual uint32_t getWidth() const { return _colorTexture->getWidth(); }
+    virtual uint32_t getHeight() const { return _colorTexture->getHeight(); }
 
 protected:
     virtual void doInit(const SwapchainInfo &info)         = 0;

--- a/cocos/renderer/gfx-validator/CommandBufferValidator.cpp
+++ b/cocos/renderer/gfx-validator/CommandBufferValidator.cpp
@@ -336,6 +336,17 @@ void CommandBufferValidator::copyBuffersToTexture(const uint8_t *const *buffers,
 void CommandBufferValidator::blitTexture(Texture *srcTexture, Texture *dstTexture, const TextureBlit *regions, uint count, Filter filter) {
     CCASSERT(!_insideRenderPass, "Command 'blitTexture' must be recorded outside render passes.");
 
+    for (uint32_t i = 0; i < count; ++i) {
+        const auto &region = regions[i];
+        CCASSERT(region.srcOffset.x + region.srcExtent.width <= srcTexture->getInfo().width, "Invalid src region");
+        CCASSERT(region.srcOffset.y + region.srcExtent.height <= srcTexture->getInfo().height, "Invalid src region");
+        CCASSERT(region.srcOffset.z + region.srcExtent.depth <= srcTexture->getInfo().depth, "Invalid src region");
+
+        CCASSERT(region.dstOffset.x + region.dstExtent.width <= dstTexture->getInfo().width, "Invalid dst region");
+        CCASSERT(region.dstOffset.y + region.dstExtent.height <= dstTexture->getInfo().height, "Invalid dst region");
+        CCASSERT(region.dstOffset.z + region.dstExtent.depth <= dstTexture->getInfo().depth, "Invalid dst region");
+    }
+
     /////////// execute ///////////
 
     Texture *actorSrcTexture = nullptr;

--- a/cocos/renderer/gfx-validator/SwapchainValidator.h
+++ b/cocos/renderer/gfx-validator/SwapchainValidator.h
@@ -41,6 +41,8 @@ public:
 
     // TO BE REMOVED
     SurfaceTransform getSurfaceTransform() const override { return _actor->getSurfaceTransform(); }
+    uint32_t getWidth() const override { return _actor->getWidth(); }
+    uint32_t getHeight() const override { return _actor->getHeight(); }
 
 protected:
     void doInit(const SwapchainInfo &info) override;

--- a/cocos/renderer/gfx-vulkan/VKDevice.cpp
+++ b/cocos/renderer/gfx-vulkan/VKDevice.cpp
@@ -87,7 +87,7 @@ CCVKDevice::~CCVKDevice() {
 bool CCVKDevice::doInit(const DeviceInfo & /*info*/) {
     _gpuContext = CC_NEW(CCVKGPUContext);
     if (!_gpuContext->initialize()) {
-        destroy();
+        CC_SAFE_DESTROY(_gpuContext)
         return false;
     }
 

--- a/cocos/renderer/gfx-vulkan/VKSwapchain.cpp
+++ b/cocos/renderer/gfx-vulkan/VKSwapchain.cpp
@@ -252,9 +252,9 @@ bool CCVKSwapchain::checkSwapchainStatus() {
     uint newHeight = surfaceCapabilities.currentExtent.height;
 
     VkSurfaceTransformFlagBitsKHR preTransform = surfaceCapabilities.currentTransform;
-#ifdef DISABLE_PRE_TRANSFORM
-    preTransform = VK_SURFACE_TRANSFORM_IDENTITY_BIT_KHR;
-#endif
+    if (!ENABLE_PRE_ROTATION) {
+        preTransform = VK_SURFACE_TRANSFORM_IDENTITY_BIT_KHR;
+    }
 
     if (preTransform & TRANSFORMS_THAT_REQUIRE_FLIPPING) {
         newHeight = surfaceCapabilities.currentExtent.width;

--- a/cocos/renderer/pipeline/deferred/DeferredPipeline.cpp
+++ b/cocos/renderer/pipeline/deferred/DeferredPipeline.cpp
@@ -137,7 +137,7 @@ void DeferredPipeline::render(const vector<scene::Camera *> &cameras) {
 void DeferredPipeline::updateQuadVertexData(const gfx::Rect &renderArea, gfx::Buffer *buffer) {
     _lastUsedRenderArea = renderArea;
     float vbData[16]    = {0};
-    genQuadVertexData(gfx::SurfaceTransform::IDENTITY, renderArea, vbData);
+    genQuadVertexData(renderArea, vbData);
     buffer->update(vbData, sizeof(vbData));
 }
 
@@ -158,7 +158,7 @@ gfx::InputAssembler *DeferredPipeline::getIAByRenderArea(const gfx::Rect &rect) 
     return ia;
 }
 
-void DeferredPipeline::genQuadVertexData(gfx::SurfaceTransform /*surfaceTransform*/, const gfx::Rect &renderArea, float *vbData) {
+void DeferredPipeline::genQuadVertexData(const gfx::Rect &renderArea, float *vbData) {
     float minX = static_cast<float>(renderArea.x) / static_cast<float>(_width);
     float maxX = static_cast<float>(renderArea.x + renderArea.width) / static_cast<float>(_width);
     float minY = static_cast<float>(renderArea.y) / static_cast<float>(_height);

--- a/cocos/renderer/pipeline/deferred/DeferredPipeline.h
+++ b/cocos/renderer/pipeline/deferred/DeferredPipeline.h
@@ -75,7 +75,7 @@ public:
     inline const UintList &       getLightIndices() const { return _lightIndices; }
     gfx::Rect                     getRenderArea(scene::Camera *camera, bool onScreen);
     void                          updateQuadVertexData(const gfx::Rect &renderArea, gfx::Buffer *buffer);
-    void                          genQuadVertexData(gfx::SurfaceTransform surfaceTransform, const gfx::Rect &renderArea, float *data);
+    void                          genQuadVertexData(const gfx::Rect &renderArea, float *data);
 
     framegraph::FrameGraph &getFrameGraph() { return _fg; }
     gfx::Color              getClearcolor(scene::Camera *camera);

--- a/cocos/renderer/pipeline/deferred/GbufferStage.cpp
+++ b/cocos/renderer/pipeline/deferred/GbufferStage.cpp
@@ -230,11 +230,8 @@ void GbufferStage::render(scene::Camera *camera) {
         builder.setViewport(viewport, _renderArea);
     };
 
-    auto gbufferExec = [&](const RenderData & /*data*/, const framegraph::DevicePassResourceTable &table) {
-        auto *           pipeline   = static_cast<DeferredPipeline *>(RenderPipeline::getInstance());
-        auto *           stage      = static_cast<GbufferStage *>(pipeline->getRenderstageByName(STAGE_NAME));
-        gfx::RenderPass *renderPass = table.getRenderPass();
-        stage->recordCommands(pipeline, renderPass);
+    auto gbufferExec = [this](const RenderData & /*data*/, const framegraph::DevicePassResourceTable &table) {
+        recordCommands(static_cast<DeferredPipeline *>(_pipeline), table.getRenderPass());
     };
 
     // Command 'updateBuffer' must be recorded outside render passes, cannot put them in execute lambda

--- a/cocos/renderer/pipeline/deferred/GbufferStage.h
+++ b/cocos/renderer/pipeline/deferred/GbufferStage.h
@@ -51,10 +51,11 @@ public:
     void activate(RenderPipeline *pipeline, RenderFlow *flow) override;
     void destroy() override;
     void render(scene::Camera *camera) override;
+
+private:
     void dispenseRenderObject2Queues();
     void recordCommands(DeferredPipeline *pipeline, gfx::RenderPass *renderPass);
 
-private:
     static RenderStageInfo initInfo;
     PlanarShadowQueue *    _planarShadowQueue = nullptr;
     RenderBatchedQueue *   _batchedQueue      = nullptr;

--- a/cocos/renderer/pipeline/deferred/LightingStage.cpp
+++ b/cocos/renderer/pipeline/deferred/LightingStage.cpp
@@ -456,6 +456,16 @@ void LightingStage::fgTransparent(scene::Camera *camera) {
         depthAttachmentInfo.endAccesses   = {gfx::AccessType::DEPTH_STENCIL_ATTACHMENT_WRITE};
 
         data.depth = framegraph::TextureHandle(builder.readFromBlackboard(DeferredPipeline::fgStrHandleDepthTexture));
+        if (!data.depth.isValid()) { // when there is no opaque object present
+            gfx::TextureInfo depthTexInfo = {
+                gfx::TextureType::TEX2D,
+                gfx::TextureUsageBit::DEPTH_STENCIL_ATTACHMENT,
+                gfx::Format::DEPTH_STENCIL,
+                pipeline->getWidth(),
+                pipeline->getHeight(),
+            };
+            data.depth = builder.create<framegraph::Texture>(DeferredPipeline::fgStrHandleDepthTexture, depthTexInfo);
+        }
         data.depth = builder.write(data.depth, depthAttachmentInfo);
         builder.writeToBlackboard(DeferredPipeline::fgStrHandleDepthTexture, data.depth);
 

--- a/cocos/renderer/pipeline/deferred/LightingStage.cpp
+++ b/cocos/renderer/pipeline/deferred/LightingStage.cpp
@@ -303,6 +303,14 @@ void LightingStage::activate(RenderPipeline *pipeline, RenderFlow *flow) {
     _reflectionComp->init(_device, 8, 8);
 
     _reflectionRenderQueue = CC_NEW(RenderQueue(std::move(info)));
+
+    gfx::SamplerInfo samplerInfo;
+    samplerInfo.minFilter = gfx::Filter::POINT;
+    samplerInfo.magFilter = gfx::Filter::POINT;
+    samplerInfo.addressU  = gfx::Address::CLAMP;
+    samplerInfo.addressV  = gfx::Address::CLAMP;
+    samplerInfo.addressW  = gfx::Address::CLAMP;
+    _defaultSampler       = _device->getSampler(samplerInfo);
 }
 
 void LightingStage::destroy() {
@@ -370,14 +378,13 @@ void LightingStage::fgLightingPass(scene::Camera *camera) {
         builder.setViewport(viewport, renderArea);
     };
 
-    auto lightingExec = [](RenderData const &data, const framegraph::DevicePassResourceTable &table) {
-        auto *      pipeline  = static_cast<DeferredPipeline *>(RenderPipeline::getInstance());
-        auto *      stage     = static_cast<LightingStage *>(pipeline->getRenderstageByName(STAGE_NAME));
+    auto lightingExec = [this](RenderData const &data, const framegraph::DevicePassResourceTable &table) {
+        auto *      pipeline  = static_cast<DeferredPipeline *>(_pipeline);
         auto *const sceneData = pipeline->getPipelineSceneData();
 
         auto *       cmdBuff        = pipeline->getCommandBuffers()[0];
         vector<uint> dynamicOffsets = {0};
-        cmdBuff->bindDescriptorSet(localSet, stage->_descriptorSet, dynamicOffsets);
+        cmdBuff->bindDescriptorSet(localSet, _descriptorSet, dynamicOffsets);
 
         uint const globalOffsets[] = {pipeline->getPipelineUBO()->getCurrentCameraUBOOffset()};
         cmdBuff->bindDescriptorSet(globalSet, pipeline->getDescriptorSet(), static_cast<uint>(std::size(globalOffsets)), globalOffsets);
@@ -390,18 +397,9 @@ void LightingStage::fgLightingPass(scene::Camera *camera) {
         gfx::PipelineState * pState         = PipelineStateManager::getOrCreatePipelineState(
             pass, shader, inputAssembler, table.getRenderPass());
 
-        gfx::SamplerInfo sinfo{
-            gfx::Filter::POINT,
-            gfx::Filter::POINT,
-            gfx::Filter::NONE,
-            gfx::Address::CLAMP,
-            gfx::Address::CLAMP,
-            gfx::Address::CLAMP,
-        };
-        auto *sampler = pipeline->getDevice()->getSampler(sinfo);
         for (uint i = 0; i < DeferredPipeline::GBUFFER_COUNT; ++i) {
             pass->getDescriptorSet()->bindTexture(i, table.getRead(data.gbuffer[i]));
-            pass->getDescriptorSet()->bindSampler(i, sampler);
+            pass->getDescriptorSet()->bindSampler(i, _defaultSampler);
         }
         pass->getDescriptorSet()->update();
 
@@ -475,19 +473,18 @@ void LightingStage::fgTransparent(scene::Camera *camera) {
         builder.setViewport(viewport, renderArea);
     };
 
-    auto transparentExec = [](RenderData const & /*data*/, const framegraph::DevicePassResourceTable &table) {
-        auto *pipeline = static_cast<DeferredPipeline *>(RenderPipeline::getInstance());
-        auto *stage    = static_cast<LightingStage *>(pipeline->getRenderstageByName(STAGE_NAME));
+    auto transparentExec = [this](RenderData const & /*data*/, const framegraph::DevicePassResourceTable &table) {
+        auto *pipeline = static_cast<DeferredPipeline *>(_pipeline);
         auto *cmdBuff  = pipeline->getCommandBuffers()[0];
 
         vector<uint> dynamicOffsets = {0};
-        cmdBuff->bindDescriptorSet(localSet, stage->_descriptorSet, dynamicOffsets);
+        cmdBuff->bindDescriptorSet(localSet, _descriptorSet, dynamicOffsets);
 
         uint const globalOffsets[] = {pipeline->getPipelineUBO()->getCurrentCameraUBOOffset()};
         cmdBuff->bindDescriptorSet(globalSet, pipeline->getDescriptorSet(), static_cast<uint>(std::size(globalOffsets)), globalOffsets);
 
         // transparent
-        for (auto *queue : stage->_renderQueues) {
+        for (auto *queue : _renderQueues) {
             queue->sort();
             queue->recordCommandBuffer(pipeline->getDevice(), table.getRenderPass(), cmdBuff);
         }
@@ -547,7 +544,7 @@ void LightingStage::fgSsprPass(scene::Camera *camera) {
     if (!_device->hasFeature(gfx::Feature::COMPUTE_SHADER)) {
         return;
     }
-    auto *pipeline = static_cast<DeferredPipeline *>(RenderPipeline::getInstance());
+    auto *pipeline = static_cast<DeferredPipeline *>(_pipeline);
 
     _denoiseIndex = 0;
     _matViewProj  = camera->matViewProj;
@@ -587,7 +584,7 @@ void LightingStage::fgSsprPass(scene::Camera *camera) {
         builder.sideEffect();
     };
 
-    auto clearExec = [&](DataClear const &data, const framegraph::DevicePassResourceTable &table) {};
+    auto clearExec = [](DataClear const &data, const framegraph::DevicePassResourceTable &table) {};
 
     // step 2 prepare compute the reflection pass, contain 1 dispatch commands, compute pipeline
     struct DataCompReflect {
@@ -624,14 +621,10 @@ void LightingStage::fgSsprPass(scene::Camera *camera) {
         builder.writeToBlackboard(reflectTexHandle, data.reflection);
     };
 
-    auto compReflectExec = [&](DataCompReflect const &data, const framegraph::DevicePassResourceTable &table) {
-        auto *pipeline = static_cast<DeferredPipeline *>(RenderPipeline::getInstance());
-        assert(pipeline != nullptr);
-        auto *stage = static_cast<LightingStage *>(pipeline->getRenderstageByName(STAGE_NAME));
-        assert(stage != nullptr);
+    auto compReflectExec = [this](DataCompReflect const &data, const framegraph::DevicePassResourceTable &table) {
+        auto *pipeline = static_cast<DeferredPipeline *>(_pipeline);
 
-        ReflectionComp *reflectionComp = stage->getReflectionComp();
-        reflectionComp->applyTexSize(stage->getSsprTexWidth(), stage->getSsprTexHeight(), stage->getMatViewProj());
+        _reflectionComp->applyTexSize(_ssprTexWidth, _ssprTexHeight, _matViewProj);
 
         auto *texReflection  = static_cast<gfx::Texture *>(table.getWrite(data.reflection));
         auto *texLightingOut = static_cast<gfx::Texture *>(table.getRead(data.lightingOut));
@@ -639,7 +632,7 @@ void LightingStage::fgSsprPass(scene::Camera *camera) {
 
         // step 1 pipeline barrier before exec
         auto *cmdBuff = pipeline->getCommandBuffers()[0];
-        cmdBuff->pipelineBarrier(reflectionComp->getBarrierPre());
+        cmdBuff->pipelineBarrier(_reflectionComp->getBarrierPre());
 
         // step 2 bind descriptors
         // layout(set = 0, binding = 0) uniform Constants {  mat4 matViewProj; vec2 texSize; };
@@ -647,9 +640,9 @@ void LightingStage::fgSsprPass(scene::Camera *camera) {
         // layout(set = 0, binding = 2) uniform sampler2D worldPositionTex;
         // layout(set = 0, binding = 3, rgba8) writeonly uniform lowp image2D reflectionTex;
         // set 0
-        gfx::DescriptorSet *reflectDesc = reflectionComp->getDescriptorSet();
-        gfx::Sampler *      sampler     = reflectionComp->getSampler();
-        gfx::Buffer *       constBuffer = reflectionComp->getConstantsBuffer();
+        gfx::DescriptorSet *reflectDesc = _reflectionComp->getDescriptorSet();
+        gfx::Sampler *      sampler     = _reflectionComp->getSampler();
+        gfx::Buffer *       constBuffer = _reflectionComp->getConstantsBuffer();
 
         reflectDesc->bindBuffer(0, constBuffer);
         reflectDesc->bindSampler(1, sampler);
@@ -657,22 +650,14 @@ void LightingStage::fgSsprPass(scene::Camera *camera) {
         reflectDesc->bindSampler(2, sampler);
         reflectDesc->bindTexture(2, texPositon);
         reflectDesc->bindTexture(3, texReflection);
-        reflectDesc->bindBuffer(4, stage->getRendElement().set->getBuffer(0));
+        reflectDesc->bindBuffer(4, _reflectionElems[_denoiseIndex].set->getBuffer(0));
         reflectDesc->update();
 
         // set 1, subModel->getDescriptorSet(0)
-        cmdBuff->bindPipelineState(const_cast<gfx::PipelineState *>(reflectionComp->getPipelineState()));
+        cmdBuff->bindPipelineState(const_cast<gfx::PipelineState *>(_reflectionComp->getPipelineState()));
         cmdBuff->bindDescriptorSet(globalSet, reflectDesc);
-        cmdBuff->dispatch(reflectionComp->getDispatchInfo());
+        cmdBuff->dispatch(_reflectionComp->getDispatchInfo());
     };
-
-    gfx::SamplerInfo samplerInfo;
-    samplerInfo.minFilter = gfx::Filter::POINT;
-    samplerInfo.magFilter = gfx::Filter::POINT;
-    samplerInfo.addressU  = gfx::Address::CLAMP;
-    samplerInfo.addressV  = gfx::Address::CLAMP;
-    samplerInfo.addressW  = gfx::Address::CLAMP;
-    auto *ssprSampler     = _device->getSampler(samplerInfo);
 
     // step 3 prepare compute the denoise pass, contain 1 dispatch commands, compute pipeline
     struct DataCompDenoise {
@@ -698,44 +683,40 @@ void LightingStage::fgSsprPass(scene::Camera *camera) {
         builder.writeToBlackboard(denoiseTexHandle[_denoiseIndex], data.denoise);
     };
 
-    auto compDenoiseExec = [&](DataCompDenoise const &data, const framegraph::DevicePassResourceTable &table) {
-        auto *pipeline = static_cast<DeferredPipeline *>(RenderPipeline::getInstance());
-        assert(pipeline != nullptr);
-        auto *stage = static_cast<LightingStage *>(pipeline->getRenderstageByName(STAGE_NAME));
-        assert(stage != nullptr);
+    auto compDenoiseExec = [this](DataCompDenoise const &data, const framegraph::DevicePassResourceTable &table) {
+        auto *pipeline = static_cast<DeferredPipeline *>(_pipeline);
 
         auto *denoiseTex    = static_cast<gfx::Texture *>(table.getWrite(data.denoise));
         auto *reflectionTex = static_cast<gfx::Texture *>(table.getRead(data.reflection));
-
-        ReflectionComp *reflectionComp = stage->getReflectionComp();
+        auto &elem       = _reflectionElems[_denoiseIndex];
 
         // pipeline barrier
         auto *cmdBuff = pipeline->getCommandBuffers()[0];
-        cmdBuff->pipelineBarrier(nullptr, const_cast<gfx::TextureBarrierList &>(reflectionComp->getBarrierBeforeDenoise()), {reflectionTex, denoiseTex});
+        cmdBuff->pipelineBarrier(nullptr, const_cast<gfx::TextureBarrierList &>(_reflectionComp->getBarrierBeforeDenoise()), {reflectionTex, denoiseTex});
 
         // bind descriptor set
-        reflectionComp->getDenoiseDescriptorSet()->bindTexture(0, reflectionTex);
-        reflectionComp->getDenoiseDescriptorSet()->bindSampler(0, reflectionComp->getSampler());
-        reflectionComp->getDenoiseDescriptorSet()->update();
+        _reflectionComp->getDenoiseDescriptorSet()->bindTexture(0, reflectionTex);
+        _reflectionComp->getDenoiseDescriptorSet()->bindSampler(0, _reflectionComp->getSampler());
+        _reflectionComp->getDenoiseDescriptorSet()->update();
 
-        stage->getRendElement().set->bindTexture(static_cast<uint>(ModelLocalBindings::STORAGE_REFLECTION), denoiseTex);
-        stage->getRendElement().set->bindSampler(static_cast<uint>(ModelLocalBindings::STORAGE_REFLECTION), ssprSampler);
+        elem.set->bindTexture(static_cast<uint>(ModelLocalBindings::STORAGE_REFLECTION), denoiseTex);
+        elem.set->bindSampler(static_cast<uint>(ModelLocalBindings::STORAGE_REFLECTION), _defaultSampler);
 
         // for render stage usage
-        stage->getRendElement().set->bindTexture(static_cast<uint>(ModelLocalBindings::SAMPLER_REFLECTION), denoiseTex);
-        stage->getRendElement().set->bindSampler(static_cast<uint>(ModelLocalBindings::SAMPLER_REFLECTION), ssprSampler);
-        stage->getRendElement().set->update();
+        elem.set->bindTexture(static_cast<uint>(ModelLocalBindings::SAMPLER_REFLECTION), denoiseTex);
+        elem.set->bindSampler(static_cast<uint>(ModelLocalBindings::SAMPLER_REFLECTION), _defaultSampler);
+        elem.set->update();
 
-        cmdBuff->bindPipelineState(const_cast<gfx::PipelineState *>(reflectionComp->getDenoisePipelineState()));
-        cmdBuff->bindDescriptorSet(globalSet, const_cast<gfx::DescriptorSet *>(reflectionComp->getDenoiseDescriptorSet()));
-        cmdBuff->bindDescriptorSet(materialSet, stage->getRendElement().set);
-        cmdBuff->dispatch(reflectionComp->getDenioseDispatchInfo());
+        cmdBuff->bindPipelineState(const_cast<gfx::PipelineState *>(_reflectionComp->getDenoisePipelineState()));
+        cmdBuff->bindDescriptorSet(globalSet, const_cast<gfx::DescriptorSet *>(_reflectionComp->getDenoiseDescriptorSet()));
+        cmdBuff->bindDescriptorSet(materialSet, elem.set);
+        cmdBuff->dispatch(_reflectionComp->getDenioseDispatchInfo());
 
         // pipeline barrier
         // dispatch -> fragment
-        cmdBuff->pipelineBarrier(nullptr, reflectionComp->getBarrierAfterDenoise(), {denoiseTex});
+        cmdBuff->pipelineBarrier(nullptr, _reflectionComp->getBarrierAfterDenoise(), {denoiseTex});
 
-        stage->addDenoiseIndex();
+        _denoiseIndex = (_denoiseIndex + 1) % _reflectionElems.size();
     };
 
     // step 4 prepare render reflector objects pass, graphics pipeline
@@ -776,13 +757,10 @@ void LightingStage::fgSsprPass(scene::Camera *camera) {
         builder.setViewport(viewport, renderArea);
     };
 
-    auto renderExec = [&](DataRender const &data, const framegraph::DevicePassResourceTable &table) {
-        auto *pipeline = static_cast<DeferredPipeline *>(RenderPipeline::getInstance());
-        assert(pipeline != nullptr);
-        auto *stage = static_cast<LightingStage *>(pipeline->getRenderstageByName(STAGE_NAME));
-        assert(stage != nullptr);
-        auto *     cmdBuff = pipeline->getCommandBuffers()[0];
-        RenderElem elem    = stage->getRendElement();
+    auto renderExec = [this](DataRender const &data, const framegraph::DevicePassResourceTable &table) {
+        auto *pipeline = static_cast<DeferredPipeline *>(_pipeline);
+        auto *cmdBuff  = pipeline->getCommandBuffers()[0];
+        auto &elem     = _reflectionElems[_denoiseIndex];
 
         // bind descriptor
         cmdBuff->bindDescriptorSet(globalSet, pipeline->getDescriptorSet());
@@ -791,16 +769,16 @@ void LightingStage::fgSsprPass(scene::Camera *camera) {
         auto *              denoiseTex = static_cast<gfx::Texture *>(table.getRead(data.denoise));
 
         descLocal->bindTexture(static_cast<uint>(ModelLocalBindings::SAMPLER_REFLECTION), denoiseTex);
-        descLocal->bindSampler(static_cast<uint>(ModelLocalBindings::SAMPLER_REFLECTION), ssprSampler);
+        descLocal->bindSampler(static_cast<uint>(ModelLocalBindings::SAMPLER_REFLECTION), _defaultSampler);
         descLocal->update();
         cmdBuff->bindDescriptorSet(localSet, descLocal);
 
-        stage->getReflectRenderQueue()->clear();
-        stage->getReflectRenderQueue()->insertRenderPass(elem.renderObject, elem.modelIndex, elem.passIndex);
+        _reflectionRenderQueue->clear();
+        _reflectionRenderQueue->insertRenderPass(elem.renderObject, elem.modelIndex, elem.passIndex);
 
         gfx::RenderPass *renderPass = table.getRenderPass();
-        stage->getReflectRenderQueue()->sort();
-        stage->getReflectRenderQueue()->recordCommandBuffer(pipeline->getDevice(), renderPass, cmdBuff);
+        _reflectionRenderQueue->sort();
+        _reflectionRenderQueue->recordCommandBuffer(pipeline->getDevice(), renderPass, cmdBuff);
     };
 
     // step 5 add framegraph passes
@@ -840,7 +818,7 @@ void LightingStage::fgSsprPass(scene::Camera *camera) {
 }
 
 void LightingStage::render(scene::Camera *camera) {
-    auto *pipeline = static_cast<DeferredPipeline *>(RenderPipeline::getInstance());
+    auto *pipeline = static_cast<DeferredPipeline *>(_pipeline);
 
     // if gbuffer pass does not exist, skip lighting pass.
     // transparent objects draw after lighting pass, can be automatically merged by FG
@@ -855,11 +833,6 @@ void LightingStage::render(scene::Camera *camera) {
     if (pipeline->getFrameGraph().hasPass(DeferredPipeline::fgStrHandleLightingPass)) {
         fgSsprPass(camera);
     }
-}
-
-RenderElem LightingStage::getRendElement() {
-    assert(_denoiseIndex != _reflectionElems.size());
-    return _reflectionElems[_denoiseIndex];
 }
 
 } // namespace pipeline

--- a/cocos/renderer/pipeline/deferred/LightingStage.h
+++ b/cocos/renderer/pipeline/deferred/LightingStage.h
@@ -59,14 +59,6 @@ public:
     void destroy() override;
     void render(scene::Camera *camera) override;
 
-    ReflectionComp *getReflectionComp() { return _reflectionComp; }
-    RenderElem      getRendElement();
-    void            addDenoiseIndex() { _denoiseIndex = (_denoiseIndex + 1) % _reflectionElems.size(); }
-    RenderQueue *   getReflectRenderQueue() const { return _reflectionRenderQueue; }
-    uint            getSsprTexWidth() const { return _ssprTexWidth; }
-    uint            getSsprTexHeight() const { return _ssprTexHeight; }
-    Mat4            getMatViewProj() const { return _matViewProj; }
-
 private:
     void gatherLights(scene::Camera *camera);
     void initLightingBuffer();
@@ -97,6 +89,8 @@ private:
 
     std::vector<RenderElem> _reflectionElems;
     uint                    _denoiseIndex = 0; // use to get corrrect texture string handle
+
+    gfx::Sampler *_defaultSampler{nullptr};
 
     // SSPR texture size
     uint _ssprTexWidth  = 0;

--- a/cocos/renderer/pipeline/deferred/PostprocessStage.cpp
+++ b/cocos/renderer/pipeline/deferred/PostprocessStage.cpp
@@ -100,7 +100,6 @@ void PostprocessStage::render(scene::Camera *camera) {
         framegraph::TextureHandle lightingOut; // read from lighting output
         framegraph::TextureHandle backBuffer;  // write to back buffer
         framegraph::TextureHandle depth;
-        framegraph::TextureHandle placerholder;
     };
 
     if (hasFlag(static_cast<gfx::ClearFlags>(camera->clearFlag), gfx::ClearFlagBit::COLOR)) {
@@ -159,7 +158,7 @@ void PostprocessStage::render(scene::Camera *camera) {
         depthAttachmentInfo.usage         = framegraph::RenderTargetAttachment::Usage::DEPTH;
         depthAttachmentInfo.loadOp        = gfx::LoadOp::CLEAR;
         depthAttachmentInfo.beginAccesses = {gfx::AccessType::DEPTH_STENCIL_ATTACHMENT_WRITE};
-        depthAttachmentInfo.endAccesses   = {gfx::AccessType::DEPTH_STENCIL_ATTACHMENT_READ};
+        depthAttachmentInfo.endAccesses   = {gfx::AccessType::DEPTH_STENCIL_ATTACHMENT_WRITE};
 
         data.depth = framegraph::TextureHandle(builder.readFromBlackboard(DeferredPipeline::fgStrHandleDepthTexture));
         if (data.depth.isValid()) {

--- a/cocos/renderer/pipeline/deferred/PostprocessStage.cpp
+++ b/cocos/renderer/pipeline/deferred/PostprocessStage.cpp
@@ -172,9 +172,8 @@ void PostprocessStage::render(scene::Camera *camera) {
         builder.setViewport(viewport, renderArea);
     };
 
-    auto postExec = [&](RenderData const &data, const framegraph::DevicePassResourceTable &table) {
-        auto *           pipeline   = static_cast<DeferredPipeline *>(RenderPipeline::getInstance());
-        auto *           stage      = static_cast<PostprocessStage *>(pipeline->getRenderstageByName(STAGE_NAME));
+    auto postExec = [this](RenderData const &data, const framegraph::DevicePassResourceTable &table) {
+        auto *           pipeline   = static_cast<DeferredPipeline *>(_pipeline);
         gfx::RenderPass *renderPass = table.getRenderPass();
 
         // bind descriptor
@@ -195,7 +194,6 @@ void PostprocessStage::render(scene::Camera *camera) {
             auto                 rendeArea = pipeline->getRenderArea(camera, camera->window->swapchain);
             gfx::InputAssembler *ia        = pipeline->getIAByRenderArea(rendeArea);
             gfx::PipelineState * pso       = PipelineStateManager::getOrCreatePipelineState(pv, sd, ia, renderPass);
-            assert(pso != nullptr);
 
             pv->getDescriptorSet()->bindTexture(0, table.getRead(data.lightingOut));
             pv->getDescriptorSet()->bindSampler(0, pipeline->getDevice()->getSampler({
@@ -214,7 +212,7 @@ void PostprocessStage::render(scene::Camera *camera) {
             cmdBuff->draw(ia);
         }
 
-        stage->getUIPhase()->render(pipeline->getFrameGraphCamera(), renderPass);
+        _uiPhase->render(pipeline->getFrameGraphCamera(), renderPass);
     };
 
     // add pass

--- a/cocos/renderer/pipeline/deferred/PostprocessStage.h
+++ b/cocos/renderer/pipeline/deferred/PostprocessStage.h
@@ -44,8 +44,6 @@ public:
     void destroy() override;
     void render(scene::Camera *camera) override;
 
-    UIPhase *getUIPhase() { return _uiPhase; }
-
 private:
     gfx::Rect _renderArea;
     UIPhase * _uiPhase = nullptr;

--- a/cocos/renderer/pipeline/forward/ForwardStage.cpp
+++ b/cocos/renderer/pipeline/forward/ForwardStage.cpp
@@ -156,9 +156,9 @@ void ForwardStage::render(scene::Camera *camera) {
     _planarShadowQueue->gatherShadowPasses(camera, cmdBuff);
 
     // render area is not oriented
-    bool flipWH        = camera->window->swapchain && static_cast<uint>(camera->window->swapchain->getSurfaceTransform()) % 2;
-    auto w             = static_cast<float>(flipWH ? camera->height : camera->width);
-    auto h             = static_cast<float>(flipWH ? camera->width : camera->height);
+    bool flipWH = camera->window->swapchain && static_cast<uint>(camera->window->swapchain->getSurfaceTransform()) % 2;
+    auto w      = static_cast<float>(flipWH ? camera->height : camera->width);
+    auto h      = static_cast<float>(flipWH ? camera->width : camera->height);
     _renderArea.x      = static_cast<int>(camera->viewPort.x * w);
     _renderArea.y      = static_cast<int>(camera->viewPort.y * h);
     _renderArea.width  = static_cast<uint>(camera->viewPort.z * w * sharedData->shadingScale);


### PR DESCRIPTION
The capture groups are lost whenever the execute lambda is passed as lvalue references.