### PR TITLE
V3.3.1 fix api 30 crash

### DIFF
--- a/cocos/platform/android/Application-android.cpp
+++ b/cocos/platform/android/Application-android.cpp
@@ -27,6 +27,7 @@
 
 #include <android_native_app_glue.h>
 #include <cstring>
+#include <sstream>
 #include "audio/include/AudioEngine.h"
 #include "base/Scheduler.h"
 #include "cocos/bindings/event/EventDispatcher.h"
@@ -58,13 +59,21 @@ namespace {
 bool setCanvasCallback(se::Object * /*global*/) {
     auto                viewLogicalSize = cc::Application::getInstance()->getViewLogicalSize();
     se::AutoHandleScope scope;
-    se::ScriptEngine *  se              = se::ScriptEngine::getInstance();
-    char                commandBuf[200] = {0};
-    sprintf(commandBuf, "window.innerWidth = %d; window.innerHeight = %d; window.windowHandler = 0x%" PRIxPTR ";",
-            static_cast<int>(viewLogicalSize.x),
-            static_cast<int>(viewLogicalSize.y),
-            reinterpret_cast<uintptr_t>(cc::cocosApp.window));
-    se->evalString(commandBuf);
+    se::ScriptEngine *  se = se::ScriptEngine::getInstance();
+    std::stringstream   ss;
+    {
+        auto windowPtr = reinterpret_cast<uintptr_t>(cc::cocosApp.window);
+        ss << "window.innerWidth = " << static_cast<int>(viewLogicalSize.x) << ";";
+        ss << "window.innerHeight = " << static_cast<int>(viewLogicalSize.y) << ";";
+        ss << "window.windowHandler = ";
+        if constexpr (sizeof(windowPtr) == 8) { // use bigint
+            ss << static_cast<uint64_t>(windowPtr) << "n;";
+        }
+        if constexpr (sizeof(windowPtr) == 4) {
+            ss << static_cast<uint32_t>(windowPtr) << ";";
+        }
+    }
+    se->evalString(ss.str().c_str());
 
     return true;
 }

--- a/cocos/platform/ios/Application-ios.mm
+++ b/cocos/platform/ios/Application-ios.mm
@@ -90,30 +90,38 @@
 namespace cc {
 
 namespace {
-    bool setCanvasCallback(se::Object *global) {
-        auto viewLogicalSize = cc::Application::getInstance()->getViewLogicalSize();
+bool setCanvasCallback(se::Object *global) {
+    auto              viewLogicalSize = cc::Application::getInstance()->getViewLogicalSize();
+    se::ScriptEngine *se              = se::ScriptEngine::getInstance();
 
-        int  nativeWidth  = static_cast<int>(viewLogicalSize.x * Device::getDevicePixelRatio());
-        int  nativeHeight = static_cast<int>(viewLogicalSize.y * Device::getDevicePixelRatio());
+    int nativeWidth  = static_cast<int>(viewLogicalSize.x * Device::getDevicePixelRatio());
+    int nativeHeight = static_cast<int>(viewLogicalSize.y * Device::getDevicePixelRatio());
 
-        // https://stackoverflow.com/questions/5795978/string-format-for-intptr-t-and-uintptr-t/41897226#41897226
-        // format intptr_t
-        //set window.innerWidth/innerHeight in css pixel units
-        uintptr_t         windowHandle = reinterpret_cast<uintptr_t>(UIApplication.sharedApplication.delegate.window.rootViewController.view);
-        std::stringstream commandBuf;
-        commandBuf << "window.innerWidth = " << viewLogicalSize.x
-                << "; window.innerHeight = " << viewLogicalSize.y
-                << "; window.nativeWidth= " << nativeWidth
-                << "; window.nativeHeight = " << nativeHeight
-                << "; window.windowHandler = " << windowHandle << ";";
-
-        se::ScriptEngine *se = se::ScriptEngine::getInstance();
-        se->evalString(commandBuf.str().c_str());
-
-        return true;
+    // https://stackoverflow.com/questions/5795978/string-format-for-intptr-t-and-uintptr-t/41897226#41897226
+    // format intptr_t
+    //set window.innerWidth/innerHeight in css pixel units
+    uintptr_t         windowHandle = reinterpret_cast<uintptr_t>(UIApplication.sharedApplication.delegate.window.rootViewController.view);
+    std::stringstream ss;
+    {
+        auto windowPtr = reinterpret_cast<uintptr_t>(windowHandle);
+        ss << "window.innerWidth = " << viewLogicalSize.x
+           << "; window.innerHeight = " << viewLogicalSize.y
+           << "; window.nativeWidth= " << nativeWidth
+           << "; window.nativeHeight = " << nativeHeight
+           << "; window.windowHandler = ";
+        if constexpr (sizeof(windowPtr) == 8) { // use bigint
+            ss << static_cast<uint64_t>(windowPtr) << "n;";
+        }
+        if constexpr (sizeof(windowPtr) == 4) {
+            ss << static_cast<uint32_t>(windowPtr) << ";";
+        }
     }
+    se->evalString(ss.str().c_str());
 
-    MyTimer *_timer;
+    return true;
+}
+
+MyTimer *_timer;
 }
 
 Application *              Application::instance  = nullptr;

--- a/cocos/platform/ios/Application-ios.mm
+++ b/cocos/platform/ios/Application-ios.mm
@@ -103,17 +103,16 @@ bool setCanvasCallback(se::Object *global) {
     uintptr_t         windowHandle = reinterpret_cast<uintptr_t>(UIApplication.sharedApplication.delegate.window.rootViewController.view);
     std::stringstream ss;
     {
-        auto windowPtr = reinterpret_cast<uintptr_t>(windowHandle);
         ss << "window.innerWidth = " << viewLogicalSize.x
            << "; window.innerHeight = " << viewLogicalSize.y
            << "; window.nativeWidth= " << nativeWidth
            << "; window.nativeHeight = " << nativeHeight
            << "; window.windowHandler = ";
-        if constexpr (sizeof(windowPtr) == 8) { // use bigint
-            ss << static_cast<uint64_t>(windowPtr) << "n;";
+        if constexpr (sizeof(windowHandle) == 8) { // use bigint
+            ss << static_cast<uint64_t>(windowHandle) << "n;";
         }
-        if constexpr (sizeof(windowPtr) == 4) {
-            ss << static_cast<uint32_t>(windowPtr) << ";";
+        if constexpr (sizeof(windowHandle) == 4) {
+            ss << static_cast<uint32_t>(windowHandle) << ";";
         }
     }
     se->evalString(ss.str().c_str());

--- a/cocos/platform/mac/Application-mac.mm
+++ b/cocos/platform/mac/Application-mac.mm
@@ -101,11 +101,21 @@ bool setCanvasCallback(se::Object *global) {
     se::ScriptEngine *se              = se::ScriptEngine::getInstance();
     NSView *          view            = [[[[NSApplication sharedApplication] delegate] getWindow] contentView];
 
-    std::stringstream commandBuf;
-    commandBuf << "window.innerWidth = " << viewLogicalSize.x
+    std::stringstream ss;
+    {
+        auto windowPtr = reinterpret_cast<uintptr_t>(view);
+        ss << "window.innerWidth = " << viewLogicalSize.x
                << "; window.innerHeight = " << viewLogicalSize.y
-               << "; window.windowHandler = " << reinterpret_cast<uintptr_t>(view) << ";";
-    se->evalString(commandBuf.str().c_str());
+               << "; window.windowHandler = ";
+
+        if constexpr (sizeof(windowPtr) == 8) { // use bigint
+            ss << static_cast<uint64_t>(windowPtr) << "n;";
+        }
+        if constexpr (sizeof(windowPtr) == 4) {
+            ss << static_cast<uint32_t>(windowPtr) << ";";
+        }
+    }
+    se->evalString(ss.str().c_str());
 
     return true;
 }

--- a/cocos/platform/ohos/Application-ohos.cpp
+++ b/cocos/platform/ohos/Application-ohos.cpp
@@ -48,13 +48,21 @@ namespace {
 bool setCanvasCallback(se::Object *global) { //NOLINT
     auto                viewLogicalSize = cc::Application::getInstance()->getViewLogicalSize();
     se::AutoHandleScope scope;
-    se::ScriptEngine *  se              = se::ScriptEngine::getInstance();
-    char                commandBuf[200] = {0};
-    auto *              view            = cc::cocosApp.pendingWindow;
+    se::ScriptEngine *  se   = se::ScriptEngine::getInstance();
+    auto *              view = cc::cocosApp.pendingWindow;
     std::stringstream   ss;
-    ss << "window.innerWidth = " << static_cast<int>(viewLogicalSize.x) << ";"
-       << "window.innerHeight = " << static_cast<int>(viewLogicalSize.y) << ";"
-       << "window.windowHandler = " << cc::cocosApp.pendingWindow << ";";
+    {
+        auto windowPtr = reinterpret_cast<uintptr_t>(view);
+        ss << "window.innerWidth = " << static_cast<int>(viewLogicalSize.x) << ";"
+           << "window.innerHeight = " << static_cast<int>(viewLogicalSize.y) << ";"
+           << "window.windowHandler = ";
+        if constexpr (sizeof(windowPtr) == 8) { // use bigint
+            ss << static_cast<uint64_t>(windowPtr) << "n;";
+        }
+        if constexpr (sizeof(windowPtr) == 4) {
+            ss << static_cast<uint64_t>(windowPtr) << ";";
+        }
+    }
     se->evalString(ss.str().c_str());
 
     return true;

--- a/templates/windows/AppDelegate.cpp
+++ b/templates/windows/AppDelegate.cpp
@@ -1,9 +1,11 @@
 #include "AppDelegate.h"
 
+// clang-format: off
 #include <MMSystem.h>
 #include <Windows.h>
 #include <shellapi.h>
 #include <sstream>
+// clang-format: on
 
 #include "cocos/bindings/jswrapper/SeApi.h"
 #include "platform/StdC.h"
@@ -64,9 +66,10 @@ bool setCanvasCallback(se::Object* global) {
         if constexpr (sizeof(windowPtr) == 4) {
             ss << static_cast<uint32_t>(windowPtr) << ";";
         }
-        se->evalString(ss.str().c_str());
-        return true;
     }
+    se->evalString(ss.str().c_str());
+    return true;
+}
 } // namespace
 
 //exported function

--- a/templates/windows/AppDelegate.cpp
+++ b/templates/windows/AppDelegate.cpp
@@ -1,11 +1,11 @@
 #include "AppDelegate.h"
 
-// clang-format: off
-#include <MMSystem.h>
+// clang-format off
 #include <Windows.h>
 #include <shellapi.h>
+#include <MMSystem.h>
 #include <sstream>
-// clang-format: on
+// clang-format on
 
 #include "cocos/bindings/jswrapper/SeApi.h"
 #include "platform/StdC.h"

--- a/templates/windows/AppDelegate.cpp
+++ b/templates/windows/AppDelegate.cpp
@@ -1,65 +1,69 @@
 #include "AppDelegate.h"
 
+#include <MMSystem.h>
 #include <Windows.h>
 #include <shellapi.h>
-#include <MMSystem.h>
 #include <sstream>
 
+#include "cocos/bindings/jswrapper/SeApi.h"
 #include "platform/StdC.h"
 #include "platform/win32/View-win32.h"
-#include "cocos/bindings/jswrapper/SeApi.h"
 
 namespace {
-    std::weak_ptr<cc::View> gView;
-    /**
+std::weak_ptr<cc::View> gView;
+/**
         @brief  This function changes the PVRFrame show/hide setting in register.
         @param  bEnable If true show the PVRFrame window, otherwise hide.
         */
-    void PVRFrameEnableControlWindow(bool bEnable) {
-        HKEY hKey = 0;
+void PVRFrameEnableControlWindow(bool bEnable) {
+    HKEY hKey = 0;
 
-        // Open PVRFrame control key, if not exist create it.
-        if (ERROR_SUCCESS != RegCreateKeyExW(HKEY_CURRENT_USER,
-                                            L"Software\\Imagination Technologies\\PVRVFRame\\STARTUP\\",
-                                            0,
-                                            0,
-                                            REG_OPTION_NON_VOLATILE,
-                                            KEY_ALL_ACCESS,
-                                            0,
-                                            &hKey,
-                                            nullptr)) {
-            return;
-        }
-
-        const WCHAR* wszValue        = L"hide_gui";
-        const WCHAR* wszNewData      = (bEnable) ? L"NO" : L"YES";
-        WCHAR        wszOldData[256] = {0};
-        DWORD        dwSize          = sizeof(wszOldData);
-        LSTATUS      status          = RegQueryValueExW(hKey, wszValue, 0, nullptr, (LPBYTE)wszOldData, &dwSize);
-        if (ERROR_FILE_NOT_FOUND == status               // the key not exist
-            || (ERROR_SUCCESS == status                  // or the hide_gui value is exist
-                && 0 != wcscmp(wszNewData, wszOldData))) // but new data and old data not equal
-        {
-            dwSize = sizeof(WCHAR) * (wcslen(wszNewData) + 1);
-            RegSetValueEx(hKey, wszValue, 0, REG_SZ, (const BYTE*)wszNewData, dwSize);
-        }
-
-        RegCloseKey(hKey);
+    // Open PVRFrame control key, if not exist create it.
+    if (ERROR_SUCCESS != RegCreateKeyExW(HKEY_CURRENT_USER,
+                                         L"Software\\Imagination Technologies\\PVRVFRame\\STARTUP\\",
+                                         0,
+                                         0,
+                                         REG_OPTION_NON_VOLATILE,
+                                         KEY_ALL_ACCESS,
+                                         0,
+                                         &hKey,
+                                         nullptr)) {
+        return;
     }
 
-    bool setCanvasCallback(se::Object* global) {
-        std::stringstream ss;
-        se::ScriptEngine* se              = se::ScriptEngine::getInstance();
-        auto              view            = gView.lock();
-        auto              handler         = view->getWindowHandler();
-        auto              viewSize        = view->getViewSize();
-        char              commandBuf[200] = {0};
-        ss << "window.innerWidth = " << viewSize[0] << "; "
-        << "window.innerHeight = " << viewSize[1] << "; "
-        << "window.windowHandler = "
-        << reinterpret_cast<intptr_t>(handler)
-        << ";";
+    const WCHAR* wszValue        = L"hide_gui";
+    const WCHAR* wszNewData      = (bEnable) ? L"NO" : L"YES";
+    WCHAR        wszOldData[256] = {0};
+    DWORD        dwSize          = sizeof(wszOldData);
+    LSTATUS      status          = RegQueryValueExW(hKey, wszValue, 0, nullptr, (LPBYTE)wszOldData, &dwSize);
+    if (ERROR_FILE_NOT_FOUND == status               // the key not exist
+        || (ERROR_SUCCESS == status                  // or the hide_gui value is exist
+            && 0 != wcscmp(wszNewData, wszOldData))) // but new data and old data not equal
+    {
+        dwSize = sizeof(WCHAR) * (wcslen(wszNewData) + 1);
+        RegSetValueEx(hKey, wszValue, 0, REG_SZ, (const BYTE*)wszNewData, dwSize);
+    }
 
+    RegCloseKey(hKey);
+}
+
+bool setCanvasCallback(se::Object* global) {
+    std::stringstream ss;
+    se::ScriptEngine* se       = se::ScriptEngine::getInstance();
+    auto              view     = gView.lock();
+    auto              handler  = view->getWindowHandler();
+    auto              viewSize = view->getViewSize();
+    {
+        auto windowPtr = reinterpret_cast<intptr_t>(handler);
+        ss << "window.innerWidth = " << viewSize[0] << "; ";
+        ss << "window.innerHeight = " << viewSize[1] << "; ";
+        ss << "window.windowHandler = ";
+        if constexpr (sizeof(windowPtr) == 8) { // use bigint
+            ss << static_cast<uint64_t>(windowPtr) << "n;";
+        }
+        if constexpr (sizeof(windowPtr) == 4) {
+            ss << static_cast<uint32_t>(windowPtr) << ";";
+        }
         se->evalString(ss.str().c_str());
         return true;
     }


### PR DESCRIPTION
fix: https://github.com/cocos-creator/engine-native/issues/3857


windowHandle  从 64 位的  0xb4***  转换到 double 出现精度丢失, 导致后续崩溃. 

- API 30: 返回的 windowHandle 是 `0xb4****`
- API 30之前: 返回的 windowHandle 是 `0x0000007****`
