### PR TITLE
Fix swapchain resize issue.

### DIFF
--- a/cocos/renderer/gfx-gles2/GLES2GPUContext.cpp
+++ b/cocos/renderer/gfx-gles2/GLES2GPUContext.cpp
@@ -274,6 +274,8 @@ void GLES2GPUContext::bindContext(bool bound) {
         resetStates();
     } else {
         makeCurrent(EGL_NO_SURFACE, EGL_NO_SURFACE, EGL_NO_CONTEXT, false);
+        _eglCurrentDrawSurface = EGL_NO_SURFACE;
+        _eglCurrentReadSurface = EGL_NO_SURFACE;
     }
 }
 

--- a/cocos/renderer/gfx-gles3/GLES3GPUContext.cpp
+++ b/cocos/renderer/gfx-gles3/GLES3GPUContext.cpp
@@ -331,7 +331,8 @@ bool GLES3GPUContext::makeCurrent(EGLSurface drawSurface, EGLSurface readSurface
     return succeeded;
 }
 
-void GLES3GPUContext::resetStates() const {
+void GLES3GPUContext::resetStates() const // NOLINT(readability-function-size)
+{
     GL_CHECK(glPixelStorei(GL_PACK_ALIGNMENT, 1));
     GL_CHECK(glPixelStorei(GL_UNPACK_ALIGNMENT, 1));
     GL_CHECK(glActiveTexture(GL_TEXTURE0));

--- a/cocos/renderer/gfx-gles3/GLES3GPUContext.cpp
+++ b/cocos/renderer/gfx-gles3/GLES3GPUContext.cpp
@@ -331,7 +331,7 @@ bool GLES3GPUContext::makeCurrent(EGLSurface drawSurface, EGLSurface readSurface
     return succeeded;
 }
 
-void GLES3GPUContext::resetStates() const // NOLINT(readability-function-size)
+void GLES3GPUContext::resetStates() const // NOLINT(google-readability-function-size)
 {
     GL_CHECK(glPixelStorei(GL_PACK_ALIGNMENT, 1));
     GL_CHECK(glPixelStorei(GL_UNPACK_ALIGNMENT, 1));

--- a/cocos/renderer/gfx-gles3/GLES3GPUContext.cpp
+++ b/cocos/renderer/gfx-gles3/GLES3GPUContext.cpp
@@ -331,8 +331,8 @@ bool GLES3GPUContext::makeCurrent(EGLSurface drawSurface, EGLSurface readSurface
     return succeeded;
 }
 
-void GLES3GPUContext::resetStates() const // NOLINT(google-readability-function-size)
-{
+void GLES3GPUContext::resetStates() const { // NOLINT
+
     GL_CHECK(glPixelStorei(GL_PACK_ALIGNMENT, 1));
     GL_CHECK(glPixelStorei(GL_UNPACK_ALIGNMENT, 1));
     GL_CHECK(glActiveTexture(GL_TEXTURE0));

--- a/cocos/renderer/gfx-gles3/GLES3GPUContext.cpp
+++ b/cocos/renderer/gfx-gles3/GLES3GPUContext.cpp
@@ -281,6 +281,8 @@ void GLES3GPUContext::bindContext(bool bound) {
         resetStates();
     } else {
         makeCurrent(EGL_NO_SURFACE, EGL_NO_SURFACE, EGL_NO_CONTEXT, false);
+        _eglCurrentDrawSurface = EGL_NO_SURFACE;
+        _eglCurrentReadSurface = EGL_NO_SURFACE;
     }
 }
 


### PR DESCRIPTION
* If the new surface created by resize event is using the same address with the one store  in context, error occurs
* Should set to EGL_NO_SURFACE when destroy the original surface