### PR TITLE
fix mtl pixelformat

### DIFF
--- a/cocos/renderer/gfx-metal/MTLShader.mm
+++ b/cocos/renderer/gfx-metal/MTLShader.mm
@@ -62,11 +62,11 @@ void CCMTLShader::doInit(const ShaderInfo &info) {
 
 void CCMTLShader::doDestroy() {
     id<MTLLibrary> vertLib = _vertLibrary;
-    _vertFunction       = nil;
+    _vertLibrary       = nil;
     id<MTLLibrary> fragLib = _fragLibrary;
-    _fragFunction     = nil;
+    _fragLibrary     = nil;
     id<MTLLibrary> cmptLib = _cmptLibrary;
-    _cmptFunction      = nil;
+    _cmptLibrary      = nil;
     
     id<MTLFunction> vertFunc = _vertFunction;
     _vertFunction       = nil;

--- a/cocos/renderer/gfx-metal/MTLUtils.mm
+++ b/cocos/renderer/gfx-metal/MTLUtils.mm
@@ -608,19 +608,10 @@ MTLPixelFormat mu::toMTLPixelFormat(Format format) {
         case Format::RGB9E5: return MTLPixelFormatRGB9E5Float;
         case Format::RGB10A2UI: return MTLPixelFormatRGB10A2Uint;
         case Format::R11G11B10F: return MTLPixelFormatRG11B10Float;
-//        case Format::D16: {
-//#if (CC_PLATFORM == CC_PLATFORM_MAC_OSX)
-//            return MTLPixelFormatDepth16Unorm;
-//#else
-//            if (@available(iOS 13.0, *))
-//                return MTLPixelFormatDepth16Unorm;
-//            else
-//                break;
-//#endif
-//        }
         case Format::DEPTH: return MTLPixelFormatDepth32Float;
 #if (CC_PLATFORM == CC_PLATFORM_MAC_OSX)
-        case Format::DEPTH_STENCIL: return MTLPixelFormatDepth24Unorm_Stencil8;
+        //case Format::DEPTH_STENCIL: return MTLPixelFormatDepth24Unorm_Stencil8;
+        case Format::DEPTH_STENCIL: return MTLPixelFormatDepth32Float_Stencil8;
         case Format::BC1:
         case Format::BC1_ALPHA: return MTLPixelFormatBC1_RGBA;
         case Format::BC1_SRGB_ALPHA: return MTLPixelFormatBC1_RGBA_sRGB;

--- a/cocos/renderer/gfx-metal/MTLUtils.mm
+++ b/cocos/renderer/gfx-metal/MTLUtils.mm
@@ -610,6 +610,7 @@ MTLPixelFormat mu::toMTLPixelFormat(Format format) {
         case Format::R11G11B10F: return MTLPixelFormatRG11B10Float;
         case Format::DEPTH: return MTLPixelFormatDepth32Float;
 #if (CC_PLATFORM == CC_PLATFORM_MAC_OSX)
+        // FIXME: works fine on imac, but invalid pixel format on intel macbook.
         //case Format::DEPTH_STENCIL: return MTLPixelFormatDepth24Unorm_Stencil8;
         case Format::DEPTH_STENCIL: return MTLPixelFormatDepth32Float_Stencil8;
         case Format::BC1:


### PR DESCRIPTION
在imac(intel)测试这是正常的，看api也只是ios不支持，官方文档也没有支出任何特殊情况，但是在现在的intel macbook上却不支持。所以保留i注释有机子在研究一下。改成32float是全平台兼容的