### PR TITLE
fix swapchain framebuffer rebuild

### DIFF
--- a/cocos/renderer/gfx-vulkan/VKCommandBuffer.cpp
+++ b/cocos/renderer/gfx-vulkan/VKCommandBuffer.cpp
@@ -151,17 +151,24 @@ void CCVKCommandBuffer::beginRenderPass(RenderPass *renderPass, Framebuffer *fbo
     for (size_t i = 0U; i < attachmentCount; ++i) {
         clearValues[i].color = {{colors[i].x, colors[i].y, colors[i].z, colors[i].w}};
     }
-
     if (depthEnabled) {
         clearValues[attachmentCount].depthStencil = {depth, stencil};
     }
+
+    Rect safeArea{
+        std::min(renderArea.x, static_cast<int32_t>(_curGPUFBO->width)),
+        std::min(renderArea.y, static_cast<int32_t>(_curGPUFBO->height)),
+        std::min(renderArea.width, _curGPUFBO->width),
+        std::min(renderArea.height, _curGPUFBO->height),
+    };
+
     VkRenderPassBeginInfo passBeginInfo{VK_STRUCTURE_TYPE_RENDER_PASS_BEGIN_INFO};
-    passBeginInfo.renderPass      = gpuRenderPass->vkRenderPass;
-    passBeginInfo.framebuffer     = framebuffer;
-    passBeginInfo.clearValueCount = utils::toUint(clearValues.size());
-    passBeginInfo.pClearValues    = clearValues.data();
-    passBeginInfo.renderArea.offset = {renderArea.x, renderArea.y};
-    passBeginInfo.renderArea.extent = {renderArea.width, renderArea.height};
+    passBeginInfo.renderPass        = gpuRenderPass->vkRenderPass;
+    passBeginInfo.framebuffer       = framebuffer;
+    passBeginInfo.clearValueCount   = utils::toUint(clearValues.size());
+    passBeginInfo.pClearValues      = clearValues.data();
+    passBeginInfo.renderArea.offset = {safeArea.x, safeArea.y};
+    passBeginInfo.renderArea.extent = {safeArea.width, safeArea.height};
 
     vkCmdBeginRenderPass(_gpuCommandBuffer->vkCommandBuffer, &passBeginInfo,
                          secondaryCBCount ? VK_SUBPASS_CONTENTS_SECONDARY_COMMAND_BUFFERS : VK_SUBPASS_CONTENTS_INLINE);
@@ -169,12 +176,12 @@ void CCVKCommandBuffer::beginRenderPass(RenderPass *renderPass, Framebuffer *fbo
     _secondaryRP = secondaryCBCount;
 
     if (!secondaryCBCount) {
-        VkViewport viewport{static_cast<float>(renderArea.x), static_cast<float>(renderArea.y),
-                            static_cast<float>(renderArea.width), static_cast<float>(renderArea.height), 0.F, 1.F};
+        VkViewport viewport{static_cast<float>(safeArea.x), static_cast<float>(safeArea.y),
+                            static_cast<float>(safeArea.width), static_cast<float>(safeArea.height), 0.F, 1.F};
         vkCmdSetViewport(_gpuCommandBuffer->vkCommandBuffer, 0, 1, &viewport);
-        _curDynamicStates.viewport = {renderArea.x, renderArea.y, renderArea.width, renderArea.height};
+        _curDynamicStates.viewport = {safeArea.x, safeArea.y, safeArea.width, safeArea.height};
         vkCmdSetScissor(_gpuCommandBuffer->vkCommandBuffer, 0, 1, &passBeginInfo.renderArea);
-        _curDynamicStates.scissor = renderArea;
+        _curDynamicStates.scissor = safeArea;
     }
 }
 

--- a/cocos/renderer/gfx-vulkan/VKCommands.cpp
+++ b/cocos/renderer/gfx-vulkan/VKCommands.cpp
@@ -607,7 +607,7 @@ void cmdFuncCCVKCreateRenderPass(CCVKDevice *device, CCVKGPURenderPass *gpuRende
         // try to deduce dependencies if not specified
 
         // first, gather necessary statistics for each attachment
-        auto updateLifeCycle = [subpassCount](AttachmentStatistics &statistics, uint32_t index, VkImageLayout layout, AttachmentStatistics::SubpassUsage usage) {
+        auto updateLifeCycle = [](AttachmentStatistics &statistics, uint32_t index, VkImageLayout layout, AttachmentStatistics::SubpassUsage usage) {
             if (statistics.records.count(index)) {
                 CC_ASSERT(statistics.records[index].layout == layout);
                 statistics.records[index].usage |= usage;
@@ -793,7 +793,6 @@ void cmdFuncCCVKCreateFramebuffer(CCVKDevice *device, CCVKGPUFramebuffer *gpuFra
     gpuFramebuffer->height      = createInfo.height;
 
     if (gpuFramebuffer->isOffscreen) {
-        CCVKGPUTextureView *gpuTextureView{colorViewCount ? gpuFramebuffer->gpuColorViews[0] : gpuFramebuffer->gpuDepthStencilView};
         createInfo.renderPass      = gpuFramebuffer->gpuRenderPass->vkRenderPass;
         createInfo.attachmentCount = utils::toUint(attachments.size());
         createInfo.pAttachments    = attachments.data();

--- a/cocos/renderer/gfx-vulkan/VKGPUObjects.h
+++ b/cocos/renderer/gfx-vulkan/VKGPUObjects.h
@@ -1104,10 +1104,23 @@ public:
     }
 
     void collect(CCVKGPUFramebuffer *gpuFramebuffer) {
-        if (_resources.size() <= _count) {
-            _resources.resize(_count * 2);
-        }
-        if (gpuFramebuffer->vkFramebuffer) {
+        if (gpuFramebuffer->swapchain) {
+            if (_device->swapchains.count(gpuFramebuffer->swapchain)) { // make sure the swapchain is still alive
+                auto &list = gpuFramebuffer->swapchain->vkSwapchainFramebufferListMap[gpuFramebuffer];
+                if (_resources.size() < _count + list.size()) {
+                    _resources.resize(_count * 2);
+                }
+                for (VkFramebuffer vkFramebuffer : list) {
+                    Resource &res     = _resources[_count++];
+                    res.type          = RecycledType::FRAMEBUFFER;
+                    res.vkFramebuffer = vkFramebuffer;
+                }
+                list.clear();
+            }
+        } else if (gpuFramebuffer->vkFramebuffer) {
+            if (_resources.size() <= _count) {
+                _resources.resize(_count * 2);
+            }
             Resource &res     = _resources[_count++];
             res.type          = RecycledType::FRAMEBUFFER;
             res.vkFramebuffer = gpuFramebuffer->vkFramebuffer;

--- a/cocos/renderer/gfx-vulkan/VKSwapchain.cpp
+++ b/cocos/renderer/gfx-vulkan/VKSwapchain.cpp
@@ -352,10 +352,6 @@ bool CCVKSwapchain::checkSwapchainStatus(uint32_t width, uint32_t height) {
     colorGPUTexture->currentAccessTypes.assign(1, THSVS_ACCESS_PRESENT);
     depthStencilGPUTexture->currentAccessTypes.assign(1, THSVS_ACCESS_DEPTH_STENCIL_ATTACHMENT_READ);
 
-    for (auto &it : _gpuSwapchain->vkSwapchainFramebufferListMap) {
-        cmdFuncCCVKCreateFramebuffer(CCVKDevice::getInstance(), it.first);
-    }
-
     _gpuSwapchain->lastPresentResult = VK_SUCCESS;
 
     return true;
@@ -406,7 +402,7 @@ void CCVKSwapchain::createVkSurface() {
     VK_CHECK(vkCreateAndroidSurfaceKHR(gpuContext->vkInstance, &surfaceCreateInfo, nullptr, &_gpuSwapchain->vkSurface));
 #elif defined(VK_USE_PLATFORM_WIN32_KHR)
     VkWin32SurfaceCreateInfoKHR surfaceCreateInfo{VK_STRUCTURE_TYPE_WIN32_SURFACE_CREATE_INFO_KHR};
-    surfaceCreateInfo.hinstance = static_cast<HINSTANCE>(GetModuleHandle(0));
+    surfaceCreateInfo.hinstance = static_cast<HINSTANCE>(GetModuleHandle(nullptr));
     surfaceCreateInfo.hwnd      = reinterpret_cast<HWND>(_windowHandle);
     VK_CHECK(vkCreateWin32SurfaceKHR(gpuContext->vkInstance, &surfaceCreateInfo, nullptr, &_gpuSwapchain->vkSurface));
 #elif defined(VK_USE_PLATFORM_METAL_EXT)

--- a/cocos/renderer/gfx-vulkan/VKTexture.cpp
+++ b/cocos/renderer/gfx-vulkan/VKTexture.cpp
@@ -29,8 +29,7 @@
 #include "VKCommands.h"
 #include "VKDevice.h"
 #include "VKTexture.h"
-#include "gfx-base/GFXDef.h"
-#include "gfx-vulkan/VKSwapchain.h"
+#include "VKSwapchain.h"
 
 namespace cc {
 namespace gfx {


### PR DESCRIPTION
Any attachment resize should trigger the framebuffer to be rebuilt, including those associated with swapchains. 
Before this patch the framebuffers are not correctly rebuilt during swapchain resizing events, and may lead to occasional crashes at VkCmdBeginRenderPass.