### PR TITLE
Remove task detect code, use singleTask only for android4.4+

### DIFF
--- a/templates/android/template/app/AndroidManifest.xml
+++ b/templates/android/template/app/AndroidManifest.xml
@@ -24,7 +24,7 @@
             android:label="@string/app_name"
             android:theme="@android:style/Theme.NoTitleBar.Fullscreen"
             android:launchMode="singleTask"
-            android:taskAffinity="" >
+            android:exported="true">
             <intent-filter>
                 <action android:name="android.intent.action.MAIN" />
 

--- a/templates/android/template/app/src/com/cocos/game/AppActivity.java
+++ b/templates/android/template/app/src/com/cocos/game/AppActivity.java
@@ -36,14 +36,6 @@ public class AppActivity extends CocosActivity {
     @Override
     protected void onCreate(Bundle savedInstanceState) {
         super.onCreate(savedInstanceState);
-        // Workaround in https://stackoverflow.com/questions/16283079/re-launch-of-activity-on-home-button-but-only-the-first-time/16447508
-        if (!isTaskRoot()) {
-            // Android launched another instance of the root activity into an existing task
-            //  so just quietly finish and go away, dropping the user back into the activity
-            //  at the top of the stack (ie: the last state of this task)
-            // Don't need to finish it again since it's finished in super.onCreate .
-            return;
-        }
         // DO OTHER INITIALIZATION BELOW
         SDKWrapper.shared().init(this);
 

--- a/templates/android/template/instantapp/AndroidManifest.xml
+++ b/templates/android/template/instantapp/AndroidManifest.xml
@@ -27,7 +27,7 @@
                 android:label="@string/app_name"
                 android:theme="@android:style/Theme.NoTitleBar.Fullscreen"
                 android:launchMode="singleTask"
-                android:taskAffinity="" >
+                android:exported="true">
             <intent-filter android:order="1">
                 <action android:name="android.intent.action.VIEW" />
 

--- a/templates/android/template/instantapp/src/com/cocos/game/InstantActivity.java
+++ b/templates/android/template/instantapp/src/com/cocos/game/InstantActivity.java
@@ -36,14 +36,6 @@ public class InstantActivity extends CocosActivity {
     @Override
     protected void onCreate(Bundle savedInstanceState) {
         super.onCreate(savedInstanceState);
-        // Workaround in https://stackoverflow.com/questions/16283079/re-launch-of-activity-on-home-button-but-only-the-first-time/16447508
-        if (!isTaskRoot()) {
-            // Android launched another instance of the root activity into an existing task
-            //  so just quietly finish and go away, dropping the user back into the activity
-            //  at the top of the stack (ie: the last state of this task)
-            // Don't need to finish it again since it's finished in super.onCreate .
-            return;
-        }
         // DO OTHER INITIALIZATION BELOW
         SDKWrapper.shared().init(this);
 


### PR DESCRIPTION
## Modification
* No need to use task detect code anymore, `singleTask` property can fit it. 
* Export game activity, so that the game can be opened outside. It is also forces required in Android API 31 (Android 13) 

## Why?

If we don't remove `taskAffinity` property, the developer will get confused when he tried to use another activity to open the game activity, and it will open 2 tasks at the same time, but the developer might not figure out why. And it also makes SDK like Admob hard to integrate.

The property `android:exported: "true"` is required in Android 13, which is released in Nov.2021, and it also makes one situation possible: Open the game from Taptap or Google play. 

