### PR TITLE
mac12+/ios15+ callback issue

### DIFF
--- a/cocos/renderer/gfx-metal/MTLBuffer.mm
+++ b/cocos/renderer/gfx-metal/MTLBuffer.mm
@@ -107,7 +107,8 @@ bool CCMTLBuffer::createMTLBuffer(uint size, MemoryUsage usage) {
 
         std::function<void(void)> destroyFunc = [=]() {
             if (mtlBuffer) {
-                [mtlBuffer setPurgeableState:MTLPurgeableStateEmpty];
+                //TODO_Zeqiang: [mac12 | ios15, ...) validate here
+//                [mtlBuffer setPurgeableState:MTLPurgeableStateEmpty];
                 [mtlBuffer release];
             }
         };
@@ -148,7 +149,8 @@ void CCMTLBuffer::doDestroy() {
 
         std::function<void(void)> destroyFunc = [=]() {
             if (mtlBuffer) {
-                [mtlBuffer setPurgeableState:MTLPurgeableStateEmpty];
+                //TODO_Zeqiang: [mac12 | ios15, ...) validate here
+//                [mtlBuffer setPurgeableState:MTLPurgeableStateEmpty];
                 [mtlBuffer release];
             }
         };

--- a/cocos/renderer/gfx-metal/MTLTexture.mm
+++ b/cocos/renderer/gfx-metal/MTLTexture.mm
@@ -238,7 +238,8 @@ void CCMTLTexture::doDestroy() {
 
     std::function<void(void)> destroyFunc = [mtlTexure]() {
         if (mtlTexure) {
-            [mtlTexure setPurgeableState:MTLPurgeableStateEmpty];
+            //TODO_Zeqiang: [mac12 | ios15, ...) validate here
+//            [mtlTexure setPurgeableState:MTLPurgeableStateEmpty];
             [mtlTexure release];
         }
     };
@@ -274,7 +275,8 @@ void CCMTLTexture::doResize(uint width, uint height, uint size) {
     if (oldMTLTexture) {
         std::function<void(void)> destroyFunc = [=]() {
             if (oldMTLTexture) {
-                [oldMTLTexture setPurgeableState:MTLPurgeableStateEmpty];
+                //TODO_Zeqiang: [mac12 | ios15, ...) validate here
+//                [oldMTLTexture setPurgeableState:MTLPurgeableStateEmpty];
                 [oldMTLTexture release];
             }
         };


### PR DESCRIPTION
问题如图：
<img width="978" alt="Screen Shot 2021-12-03 at 9 43 18 PM" src="https://user-images.githubusercontent.com/18626925/144612686-81ba121e-d80b-499f-b735-c78dff9479da.png">
测试机型：iphone6p: ios 14, iphone Xs max: ios 14, mac intel: macOs 12, mac m1: macOs 11.
- 在普通iphone，mac上执行正常，执行顺序是1，2，3，即先cpu present命令，往下执行nsautoreleasepool的回收，之后异步回调到onPresentComplete，逻辑上正是如此，表现也正常；
- 在mac12上，大概率出现1，3，2的执行顺序，即present命令上传之后onpresentComplete马上完成了，抢占了nsautoreleasepool的回收，导致在CCMTLGarbageCollectionPool执行clear里面的各种资源的detroyFunc的时候，resource其实并没有完全被release，从而触发setPurgeState的时候校验：资源正在使用，无法被设置PurgeableState为volatile属性。

试过手动用semaphore同步强制让顺序变成1，2，3，但是依然还会有校验的情况。

两种方案：
1. 去掉setpurgeablesate。用performance tool 观察了一下，程序基本稳定，并没有明显增长，只是偶尔增长也会降回来。
2. 去掉releasepool，手动控制诸如mtlcommandbuffer生命周期。试了试也可以，但是不确定有没有消除掉其他所有的泄漏。

第一种改动量最小所以就先第一种，之前加这个setpurgeablesate的原因就是开发者观测到xcode显示内存一直增加，这个setpurgeablesate只是一种是否立即被清除的标记，实际allocation并没有增长。

综上，怀疑是ios15/mac12更新的一些机制，导致gpu回调变得更快抢占了autorelease的时机。
//TODO：最好还是不用autoreleasepool，感觉控制力变弱了，现在这个方案一像是一种妥协。
