### PR TITLE
fix forward pass initial layout

### DIFF
--- a/cocos/renderer/gfx-agent/SwapchainAgent.cpp
+++ b/cocos/renderer/gfx-agent/SwapchainAgent.cpp
@@ -73,12 +73,14 @@ void SwapchainAgent::doInit(const SwapchainInfo &info) {
     SwapchainTextureInfo textureInfo;
     textureInfo.swapchain = this;
     textureInfo.format    = _actor->getColorTexture()->getFormat();
-    textureInfo.width     = info.width;
-    textureInfo.height    = info.height;
+    textureInfo.width     = _actor->getWidth();
+    textureInfo.height    = _actor->getHeight();
     initTexture(textureInfo, _colorTexture);
 
     textureInfo.format = _actor->getDepthStencilTexture()->getFormat();
     initTexture(textureInfo, _depthStencilTexture);
+
+    _transform = _actor->getSurfaceTransform();
 }
 
 void SwapchainAgent::doDestroy() {
@@ -112,6 +114,7 @@ void SwapchainAgent::doResize(uint32_t width, uint32_t height, SurfaceTransform 
     auto *depthStencilTexture = static_cast<TextureAgent *>(_depthStencilTexture);
     colorTexture->_info.width = depthStencilTexture->_info.width = _actor->getWidth();
     colorTexture->_info.height = depthStencilTexture->_info.height = _actor->getHeight();
+
     _transform = _actor->getSurfaceTransform();
 }
 

--- a/cocos/renderer/gfx-gles2/GLES2GPUContext.cpp
+++ b/cocos/renderer/gfx-gles2/GLES2GPUContext.cpp
@@ -234,8 +234,7 @@ bool GLES2GPUContext::initialize(GLES2GPUStateCache *stateCache, GLES2GPUConstan
     size_t threadID{std::hash<std::thread::id>{}(std::this_thread::get_id())};
     _sharedContexts[threadID] = eglDefaultContext;
 
-    makeCurrent(eglDefaultSurface, eglDefaultSurface, eglDefaultContext);
-    resetStates();
+    bindContext(true);
 
     return true;
 }
@@ -270,7 +269,7 @@ void GLES2GPUContext::destroy() {
 
 void GLES2GPUContext::bindContext(bool bound) {
     if (bound) {
-        makeCurrent(_eglCurrentDrawSurface, _eglCurrentReadSurface, eglDefaultContext);
+        makeCurrent(eglDefaultSurface, eglDefaultSurface, eglDefaultContext);
         resetStates();
     } else {
         makeCurrent(EGL_NO_SURFACE, EGL_NO_SURFACE, EGL_NO_CONTEXT, false);

--- a/cocos/renderer/gfx-gles3/GLES3GPUContext.cpp
+++ b/cocos/renderer/gfx-gles3/GLES3GPUContext.cpp
@@ -241,8 +241,7 @@ bool GLES3GPUContext::initialize(GLES3GPUStateCache *stateCache, GLES3GPUConstan
     size_t threadID{std::hash<std::thread::id>{}(std::this_thread::get_id())};
     _sharedContexts[threadID] = eglDefaultContext;
 
-    makeCurrent(eglDefaultSurface, eglDefaultSurface, eglDefaultContext);
-    resetStates();
+    bindContext(true);
 
     return true;
 }
@@ -277,7 +276,7 @@ void GLES3GPUContext::destroy() {
 
 void GLES3GPUContext::bindContext(bool bound) {
     if (bound) {
-        makeCurrent(_eglCurrentDrawSurface, _eglCurrentReadSurface, eglDefaultContext);
+        makeCurrent(eglDefaultSurface, eglDefaultSurface, eglDefaultContext);
         resetStates();
     } else {
         makeCurrent(EGL_NO_SURFACE, EGL_NO_SURFACE, EGL_NO_CONTEXT, false);

--- a/cocos/renderer/gfx-validator/RenderPassValidator.cpp
+++ b/cocos/renderer/gfx-validator/RenderPassValidator.cpp
@@ -55,6 +55,15 @@ void RenderPassValidator::doInit(const RenderPassInfo &info) {
         }
     }
 
+    for (auto & attachment : _colorAttachments) {
+        if (attachment.loadOp == LoadOp::LOAD && attachment.beginAccesses.empty()) {
+            CCASSERT(false, "Attachment missing beginAccesses for LoadOp::LOAD");
+        }
+    }
+    if ((_depthStencilAttachment.depthLoadOp == LoadOp::LOAD || _depthStencilAttachment.stencilLoadOp == LoadOp::LOAD) && _depthStencilAttachment.beginAccesses.empty()) {
+        CCASSERT(false, "Attachment missing beginAccesses for LoadOp::LOAD");
+    }
+
     /////////// execute ///////////
 
     _actor->initialize(info);

--- a/cocos/renderer/gfx-validator/SwapchainValidator.cpp
+++ b/cocos/renderer/gfx-validator/SwapchainValidator.cpp
@@ -69,12 +69,14 @@ void SwapchainValidator::doInit(const SwapchainInfo &info) {
     SwapchainTextureInfo textureInfo;
     textureInfo.swapchain = this;
     textureInfo.format    = _actor->getColorTexture()->getFormat();
-    textureInfo.width     = info.width;
-    textureInfo.height    = info.height;
+    textureInfo.width     = _actor->getWidth();
+    textureInfo.height    = _actor->getHeight();
     initTexture(textureInfo, _colorTexture);
 
     textureInfo.format = _actor->getDepthStencilTexture()->getFormat();
     initTexture(textureInfo, _depthStencilTexture);
+
+    _transform = _actor->getSurfaceTransform();
 }
 
 void SwapchainValidator::doDestroy() {

--- a/cocos/renderer/pipeline/forward/ForwardStage.cpp
+++ b/cocos/renderer/pipeline/forward/ForwardStage.cpp
@@ -179,6 +179,7 @@ void ForwardStage::render(scene::Camera *camera) {
                 colorAttachmentInfo.loadOp = gfx::LoadOp::DISCARD;
             } else {
                 colorAttachmentInfo.loadOp = gfx::LoadOp::LOAD;
+                colorAttachmentInfo.beginAccesses = {gfx::AccessType::COLOR_ATTACHMENT_WRITE};
             }
         }
         colorAttachmentInfo.endAccesses   = {gfx::AccessType::COLOR_ATTACHMENT_WRITE};


### PR DESCRIPTION
when load op is load, begin access should always be specified to avoid undefined initial layout

maybe related to https://github.com/cocos-creator/3d-tasks/issues/10200

https://github.com/cocos-creator/3d-tasks/issues/10187
https://github.com/cocos-creator/3d-tasks/issues/10259