### PR TITLE
Fix Editbox bug

### DIFF
--- a/cocos/platform/android/java/src/com/cocos/lib/CocosEditBoxActivity.java
+++ b/cocos/platform/android/java/src/com/cocos/lib/CocosEditBoxActivity.java
@@ -379,7 +379,7 @@ public class CocosEditBoxActivity extends Activity {
         } else {
             int buttonTextPadding = mEditText.getPaddingBottom() / 2;
             mButton.setPadding(editPadding, buttonTextPadding, editPadding, buttonTextPadding);
-            mButtonParams.setMargins(0, buttonTextPadding, 2, 0);
+            mButtonParams.setMargins(0, buttonTextPadding, 0, 0);
             mButtonLayout.setVisibility(View.VISIBLE);
         }
 


### PR DESCRIPTION
[ Bug ] For android API 18, edit-box's text would be occluded.
[ Fixed ] remove unnecessary margin
* https://github.com/cocos-creator/3d-tasks/issues/9305