### PR TITLE
Remove origin code for twice call to java method.

### DIFF
--- a/cocos/platform/java/jni/JniCocosOrientationHelper.cpp
+++ b/cocos/platform/java/jni/JniCocosOrientationHelper.cpp
@@ -28,9 +28,19 @@
 #include "platform/java/jni/JniHelper.h"
 
 extern "C" {
-//NOLINTNEXTLINE
+// NOLINTNEXTLINE
 JNIEXPORT void JNICALL Java_com_cocos_lib_CocosOrientationHelper_nativeOnOrientationChanged(JNIEnv *env, jobject thiz, jint rotation) {
-    auto orientation = cc::Device::getDeviceOrientation();
-    cc::EventDispatcher::dispatchOrientationChangeEvent((int)orientation);
+    int orientation;
+    switch (rotation) {
+        case 0://ROTATION_0
+            orientation = (int)cc::Device::Orientation::PORTRAIT;
+        case 1://ROTATION_90
+            orientation = (int)cc::Device::Orientation::LANDSCAPE_RIGHT;
+        case 2://ROTATION_180
+            orientation = (int)cc::Device::Orientation::PORTRAIT_UPSIDE_DOWN;
+        case 3://ROTATION_270
+            orientation = (int)cc::Device::Orientation::LANDSCAPE_LEFT;
+    }
+    cc::EventDispatcher::dispatchOrientationChangeEvent(orientation);
 }
 }


### PR DESCRIPTION
* remove use of cc::Device::getDeviceOrientation(), which will call java method again rather than jint rotation.
* Use switch and change it to cc::Device::Orientation, because ROTATION only defined on Android and OHOS.
 