### PR TITLE
issue 10384 memory leak fix

### DIFF
--- a/cocos/base/AutoreleasePool.cpp
+++ b/cocos/base/AutoreleasePool.cpp
@@ -58,18 +58,17 @@ LegacyAutoreleasePool::~LegacyAutoreleasePool() {
 }
 
 void LegacyAutoreleasePool::addObject(Ref *object) {
-    _managedObjectArray.push_back(object);
+    _managedObjectArray.emplace_back(object);
 }
 
 void LegacyAutoreleasePool::clear() {
 #if defined(CC_DEBUG) && (CC_DEBUG > 0)
     _isClearing = true;
 #endif
-    std::vector<Ref *> releasings;
-    releasings.swap(_managedObjectArray);
-    for (const auto &obj : releasings) {
+    for (const auto &obj : _managedObjectArray) {
         obj->release();
     }
+    _managedObjectArray.clear();
 #if defined(CC_DEBUG) && (CC_DEBUG > 0)
     _isClearing = false;
 #endif
@@ -145,7 +144,7 @@ bool PoolManager::isObjectInPools(Ref *obj) const {
 }
 
 void PoolManager::push(LegacyAutoreleasePool *pool) {
-    _releasePoolStack.push_back(pool);
+    _releasePoolStack.emplace_back(pool);
 }
 
 void PoolManager::pop() {

--- a/cocos/base/AutoreleasePool.cpp
+++ b/cocos/base/AutoreleasePool.cpp
@@ -30,7 +30,7 @@
 
 namespace cc {
 
-LegacyAutoreleasePool::LegacyAutoreleasePool()
+LegacyAutoreleasePool::LegacyAutoreleasePool() //NOLINT(misc-no-recursion)
 #if defined(CC_DEBUG) && (CC_DEBUG > 0)
 : _isClearing(false)
 #endif
@@ -65,10 +65,11 @@ void LegacyAutoreleasePool::clear() {
 #if defined(CC_DEBUG) && (CC_DEBUG > 0)
     _isClearing = true;
 #endif
-    for (const auto &obj : _managedObjectArray) {
+    std::vector<Ref *> releasings;
+    releasings.swap(_managedObjectArray);
+    for (const auto &obj : releasings) {
         obj->release();
     }
-    _managedObjectArray.clear();
 #if defined(CC_DEBUG) && (CC_DEBUG > 0)
     _isClearing = false;
 #endif
@@ -100,7 +101,7 @@ void LegacyAutoreleasePool::dump() {
 
 PoolManager *PoolManager::_singleInstance = nullptr;
 
-PoolManager *PoolManager::getInstance() {
+PoolManager *PoolManager::getInstance() {//NOLINT(misc-no-recursion)
     if (_singleInstance == nullptr) {
         _singleInstance = new (std::nothrow) PoolManager();
         _singleInstance->push(new LegacyAutoreleasePool());

--- a/cocos/base/AutoreleasePool.cpp
+++ b/cocos/base/AutoreleasePool.cpp
@@ -76,7 +76,7 @@ void LegacyAutoreleasePool::clear() {
 }
 
 bool LegacyAutoreleasePool::contains(Ref *object) const {
-    for (const auto &obj : _managedObjectArray) {
+    for (const auto &obj : _managedObjectArray) {//NOLINT(readability-use-anyofallof)
         if (obj == object) {
             return true;
         }
@@ -136,7 +136,7 @@ LegacyAutoreleasePool *PoolManager::getCurrentPool() const {
 }
 
 bool PoolManager::isObjectInPools(Ref *obj) const {
-    for (const auto &pool : _releasePoolStack) {
+    for (const auto &pool : _releasePoolStack) {//NOLINT(readability-use-anyofallof)
         if (pool->contains(obj)) {
             return true;
         }

--- a/cocos/bindings/event/EventDispatcher.cpp
+++ b/cocos/bindings/event/EventDispatcher.cpp
@@ -106,7 +106,7 @@ void EventDispatcher::dispatchTouchEvent(const struct TouchEvent &touchEvent) {
     while (jsTouchObjPool.size() < touchEvent.touches.size()) {
         se::Object *touchObj = se::Object::createPlainObject();
         touchObj->root();
-        jsTouchObjPool.push_back(touchObj);
+        jsTouchObjPool.emplace_back(touchObj);
     }
 
     uint32_t touchIndex = 0;
@@ -143,7 +143,7 @@ void EventDispatcher::dispatchTouchEvent(const struct TouchEvent &touchEvent) {
     }
 
     se::ValueArray args;
-    args.push_back(se::Value(jsTouchObjArray));
+    args.emplace_back(se::Value(jsTouchObjArray));
     EventDispatcher::doDispatchEvent(nullptr, eventName, args);
 }
 
@@ -194,7 +194,7 @@ void EventDispatcher::dispatchMouseEvent(const struct MouseEvent &mouseEvent) {
     }
 
     se::ValueArray args;
-    args.push_back(se::Value(jsMouseEventObj));
+    args.emplace_back(se::Value(jsMouseEventObj));
     EventDispatcher::doDispatchEvent(eventName, jsFunctionName, args);
 }
 
@@ -226,7 +226,7 @@ void EventDispatcher::dispatchKeyboardEvent(const struct KeyboardEvent &keyboard
     jsKeyboardEventObj->setProperty("repeat", se::Value(keyboardEvent.action == KeyboardEvent::Action::REPEAT));
     jsKeyboardEventObj->setProperty("keyCode", se::Value(keyboardEvent.key));
     se::ValueArray args;
-    args.push_back(se::Value(jsKeyboardEventObj));
+    args.emplace_back(se::Value(jsKeyboardEventObj));
     EventDispatcher::doDispatchEvent(nullptr, eventName, args);
 }
 
@@ -245,7 +245,7 @@ void EventDispatcher::dispatchTickEvent(float /*dt*/) {
 
     se::ValueArray args;
     int64_t      milliSeconds = std::chrono::duration_cast<std::chrono::milliseconds>(prevTime - se::ScriptEngine::getInstance()->getStartTime()).count();
-    args.push_back(se::Value(static_cast<double>(milliSeconds)));
+    args.emplace_back(se::Value(static_cast<double>(milliSeconds)));
 
     tickVal.toObject()->call(args, nullptr);
 }
@@ -260,7 +260,7 @@ void EventDispatcher::dispatchResizeEvent(int width, int height) {
     jsResizeEventObj->setProperty("width", se::Value(width));
     jsResizeEventObj->setProperty("height", se::Value(height));
     se::ValueArray args;
-    args.push_back(se::Value(jsResizeEventObj));
+    args.emplace_back(se::Value(jsResizeEventObj));
     EventDispatcher::doDispatchEvent(EVENT_RESIZE, "onResize", args);
 }
 
@@ -283,7 +283,7 @@ void EventDispatcher::dispatchOrientationChangeEvent(int orientation) {
         jsOrientationEventObj->setProperty("orientation", se::Value(orientation));
 
         se::ValueArray args;
-        args.push_back(se::Value(jsOrientationEventObj));
+        args.emplace_back(se::Value(jsOrientationEventObj));
         func.toObject()->call(args, nullptr);
     }
 }

--- a/cocos/renderer/pipeline/PipelineSceneData.h
+++ b/cocos/renderer/pipeline/PipelineSceneData.h
@@ -67,9 +67,9 @@ public:
     inline void                                                                setMatShadowProj(const Mat4 &matShadowProj) { _matShadowProj = matShadowProj; }
     inline Mat4                                                                getMatShadowViewProj() const { return _matShadowViewProj; }
     inline void                                                                setMatShadowViewProj(const Mat4 &matShadowViewProj) { _matShadowViewProj = matShadowViewProj; }
-    inline void                                                                addRenderObject(RenderObject &&obj) { _renderObjects.emplace_back(std::move(obj)); }
+    inline void                                                                addRenderObject(RenderObject &&obj) { _renderObjects.emplace_back(obj); }
     inline void                                                                clearRenderObjects() { _renderObjects.clear(); }
-    inline void                                                                addValidPunctualLight(scene::Light *light) { _validPunctualLights.emplace_back(std::move(light)); }
+    inline void                                                                addValidPunctualLight(scene::Light *light) { _validPunctualLights.emplace_back(light); }
     inline void                                                                clearValidPunctualLights() { _validPunctualLights.clear(); }
 
 private:

--- a/cocos/renderer/pipeline/PipelineSceneData.h
+++ b/cocos/renderer/pipeline/PipelineSceneData.h
@@ -67,6 +67,10 @@ public:
     inline void                                                                setMatShadowProj(const Mat4 &matShadowProj) { _matShadowProj = matShadowProj; }
     inline Mat4                                                                getMatShadowViewProj() const { return _matShadowViewProj; }
     inline void                                                                setMatShadowViewProj(const Mat4 &matShadowViewProj) { _matShadowViewProj = matShadowViewProj; }
+    inline void                                                                addRenderObject(RenderObject &&obj) { _renderObjects.emplace_back(std::move(obj)); }
+    inline void                                                                clearRenderObjects() { _renderObjects.clear(); }
+    inline void                                                                addValidPunctualLight(scene::Light *light) { _validPunctualLights.emplace_back(std::move(light)); }
+    inline void                                                                clearValidPunctualLights() { _validPunctualLights.clear(); }
 
 private:
     RenderObjectList     _renderObjects;

--- a/cocos/scene/SkinningModel.cpp
+++ b/cocos/scene/SkinningModel.cpp
@@ -31,10 +31,10 @@
 namespace cc {
 namespace scene {
 
-    std::vector<JointTransform *> SkinningModel::_transStacks;
+    std::vector<JointTransform *> SkinningModel::transStacks;
 
 void SkinningModel::updateWorldMatrix(JointInfo* info, uint32_t stamp) {
-    _transStacks.clear();
+    transStacks.clear();
 
     int i = -1;
     _worldMatrix.setIdentity();
@@ -47,7 +47,7 @@ void SkinningModel::updateWorldMatrix(JointInfo* info, uint32_t stamp) {
             break;
         }
         currTransform->stamp = stamp;
-        _transStacks.emplace_back(currTransform);
+        transStacks.emplace_back(currTransform);
         i++;
         if (i >= parentSize) {
             break;
@@ -55,7 +55,7 @@ void SkinningModel::updateWorldMatrix(JointInfo* info, uint32_t stamp) {
         currTransform = &info->parents[i];
     }
     while (i > -1) {
-        currTransform = _transStacks[i--];
+        currTransform = transStacks[i--];
         auto* node    = currTransform->node;
         Mat4::fromRTS(node->getRotation(), node->getPosition(), node->getScale(), &currTransform->local);
         Mat4::multiply(_worldMatrix, currTransform->local, &currTransform->world);

--- a/cocos/scene/SkinningModel.cpp
+++ b/cocos/scene/SkinningModel.cpp
@@ -30,6 +30,9 @@
 
 namespace cc {
 namespace scene {
+
+    std::vector<JointTransform *> SkinningModel::_transStacks;
+
 void SkinningModel::updateWorldMatrix(JointInfo* info, uint32_t stamp) {
     _transStacks.clear();
 

--- a/cocos/scene/SkinningModel.h
+++ b/cocos/scene/SkinningModel.h
@@ -90,6 +90,7 @@ private:
     std::vector<gfx::Buffer *>                                     _buffers;
     std::vector<JointInfo>                                         _joints;
     std::vector<std::array<float, pipeline::UBOSkinning::COUNT> *> _dataArray;
+    std::vector<JointTransform *>                                  _transStacks;
 };
 
 } // namespace scene

--- a/cocos/scene/SkinningModel.h
+++ b/cocos/scene/SkinningModel.h
@@ -90,7 +90,7 @@ private:
     std::vector<gfx::Buffer *>                                     _buffers;
     std::vector<JointInfo>                                         _joints;
     std::vector<std::array<float, pipeline::UBOSkinning::COUNT> *> _dataArray;
-    std::vector<JointTransform *>                                  _transStacks;
+    static std::vector<JointTransform *>                           _transStacks;
 };
 
 } // namespace scene

--- a/cocos/scene/SkinningModel.h
+++ b/cocos/scene/SkinningModel.h
@@ -90,7 +90,7 @@ private:
     std::vector<gfx::Buffer *>                                     _buffers;
     std::vector<JointInfo>                                         _joints;
     std::vector<std::array<float, pipeline::UBOSkinning::COUNT> *> _dataArray;
-    static std::vector<JointTransform *>                           _transStacks;
+    static std::vector<JointTransform *>                           transStacks;
 };
 
 } // namespace scene


### PR DESCRIPTION
Re: https://github.com/cocos-creator/3d-tasks/issues/10384

Changelog:
- use 'emplace_back' other than 'push_back'
- 针对SceneCulling中用到的来自于SceneData的validPunctualLight和renderObjects，改为直接通过接口进行clear和添加元素
- 将SkinningModel的updateWorldMatrix里面的transStacks变为成员变量
- 在LegacyAutoreleasePool中复用_managedObjectArray

在3.3.2内存增量中，C++部分的已经全部清零。在3.4检测到新增了FG层面的内存分配。
![image](https://user-images.githubusercontent.com/95199410/146734784-cdfe0a8f-8b15-47aa-9d27-b5539563df1a.png)

