### PR TITLE
fix issue 3233 2D blend

### DIFF
--- a/cocos/renderer/scene/assembler/SimpleSprite2D.cpp
+++ b/cocos/renderer/scene/assembler/SimpleSprite2D.cpp
@@ -93,6 +93,26 @@ void SimpleSprite2D::fillBuffers(NodeProxy* node, ModelBatcher* batcher, std::si
     float* dstWorldVerts = buffer->vData + vBufferOffset;
     memcpy(dstWorldVerts, data->getVertices(), 4 * _bytesPerVertex);
 
+    uint8_t* ptrAlpha = (uint8_t*)data->getVertices() + _alphaOffset;
+    size_t dataPerVertex = _bytesPerVertex / sizeof(uint8_t);
+    uint8_t* ptrColor = (uint8_t*)dstWorldVerts + _vfColor->offset;
+
+    for (uint32_t i = 0; i < 4; ++i)
+    {
+        float alpha = *(ptrAlpha) / 255.0;
+
+        uint8_t valueB = *(ptrAlpha - 1) * alpha;
+        uint8_t valueG = *(ptrAlpha - 2) * alpha;
+        uint8_t valueR = *(ptrAlpha - 3) * alpha;
+
+        *ptrColor       = valueR;
+        *(ptrColor + 1) = valueG;
+        *(ptrColor + 2) = valueB;
+
+        ptrAlpha += dataPerVertex;
+        ptrColor += dataPerVertex;
+    }
+
     // Copy index buffer with vertex offset
     uint16_t* srcIndices = (uint16_t*)data->getIndices();
     uint16_t* dstIndices = buffer->iData;
@@ -100,6 +120,37 @@ void SimpleSprite2D::fillBuffers(NodeProxy* node, ModelBatcher* batcher, std::si
     {
         dstIndices[indexId++] = vertexId + srcIndices[j];
     }
+}
+
+void SimpleSprite2D::updateOpacity(std::size_t index, uint8_t opacity)
+{
+    // has no color info in vertex buffer
+    if(!_vfColor || !_datas || !_vfmt)
+    {
+        return;
+    }
+    
+    const IARenderData& ia = _iaDatas[index];
+    std::size_t meshIndex = ia.meshIndex >= 0 ? ia.meshIndex : index;
+    
+    RenderData* data = _datas->getRenderData(meshIndex);
+    if (!data)
+    {
+        return;
+    }
+    
+    CCASSERT(data->getVBytes() % _bytesPerVertex == 0, "Assembler::updateOpacity vertices data doesn't follow vertex format");
+    uint32_t vertexCount = (uint32_t)data->getVBytes() / _bytesPerVertex;
+    
+    size_t dataPerVertex = _bytesPerVertex / sizeof(uint8_t);
+    uint8_t* ptrAlpha = (uint8_t*)data->getVertices() + _alphaOffset;
+    for (uint32_t i = 0; i < vertexCount; ++i)
+    {
+       *ptrAlpha = opacity;
+       ptrAlpha += dataPerVertex;
+    }
+    
+    *_dirty &= ~VERTICES_OPACITY_CHANGED;
 }
 
 RENDERER_END

--- a/cocos/renderer/scene/assembler/SimpleSprite2D.hpp
+++ b/cocos/renderer/scene/assembler/SimpleSprite2D.hpp
@@ -34,6 +34,7 @@ public:
     SimpleSprite2D();
     virtual ~SimpleSprite2D();
     virtual void fillBuffers(NodeProxy* node, ModelBatcher* batcher, std::size_t index) override;
+    virtual void updateOpacity(std::size_t index, uint8_t opacity) override;
 };
 
 RENDERER_END


### PR DESCRIPTION
Re:
https://github.com/cocos-creator/2d-tasks/issues/3233

Changelog:
- 在SimpleSprite2D中重载updateOpacity函数，仅更新颜色alpha值
- 在SimpleSprite2D的fillBuffers中，拷贝顶点属性后，再使用alpha值更新一遍顶点RGB值

问题原因
  原先的方式，每调整一次opacity值，因为预乘，都会改变顶点颜色的RGB值，然后再写回顶点中，下一次调整opacity，实际上拿出来的RGB已经受前一次调整opacity值操作的影响了。
　　正确的做法应该是使用初始颜色值乘上当前的alpha值（由opacity计算得到）作为顶点颜色。