### PR TITLE
Fix wrong initialize logic of setting uuid for occlusionQueryMaterial

### DIFF
--- a/cocos/renderer/pipeline/PipelineSceneData.cpp
+++ b/cocos/renderer/pipeline/PipelineSceneData.cpp
@@ -83,7 +83,7 @@ void PipelineSceneData::initOcclusionQuery() {
 
     if (!_occlusionQueryMaterial) {
         _occlusionQueryMaterial = new Material();
-        _occlusionQueryMaterial->initDefault(std::string{"default-occlusion-query-material"});
+        _occlusionQueryMaterial->setUuid("default-occlusion-query-material");
         IMaterialInfo info;
         info.effectName = "occlusion-query";
         _occlusionQueryMaterial->initialize(info);


### PR DESCRIPTION
![企业微信截图_16419858105936](https://user-images.githubusercontent.com/493372/149252585-f7d7f149-ff82-448b-b795-e7da3f7a2dc2.png)
