### PR TITLE
fix iOS keyboard hide issue.

### DIFF
--- a/cocos/ui/edit-box/EditBox-ios.mm
+++ b/cocos/ui/edit-box/EditBox-ios.mm
@@ -353,8 +353,16 @@ namespace
 
 -(void)keyboardWillHide: (NSNotification*) notification
 {
-    cocos2d::EditBox::complete();
-    cocos2d::EditBox::hide();
+    NSDictionary *info = [notification userInfo];
+    
+    CGRect beginKeyboardRect = [[info objectForKey:UIKeyboardFrameBeginUserInfoKey] CGRectValue];
+    CGRect endKeyboardRect = [[info objectForKey:UIKeyboardFrameEndUserInfoKey] CGRectValue];
+    CGFloat yOffset = endKeyboardRect.origin.y - beginKeyboardRect.origin.y;
+    
+    if (yOffset <= 0) {
+        cocos2d::EditBox::complete();
+        cocos2d::EditBox::hide();
+    }
 }
 @end
 


### PR DESCRIPTION
iOS keyboard hiding may be in the word selection screen. so check the offset of keyboard, if keyboard no work, offset <= 0

**BUG, Scrolling to select a word will exit the keyboard directly.**
![image](https://user-images.githubusercontent.com/8321365/149273794-e8706023-39c2-44b7-809b-15b45be8384d.png)
