### PR TITLE
Revert "allow tick() in background (#4083)"

### DIFF
--- a/cocos/platform/android/jni/JniCocosActivity.cpp
+++ b/cocos/platform/android/jni/JniCocosActivity.cpp
@@ -67,28 +67,6 @@ int readCommand(int8_t &cmd) {
     return read(pipeRead, &cmd, sizeof(cmd));
 }
 
-int readCommandWithTimeout(int8_t &cmd, int delayMS) {
-    if (delayMS > 0) {
-        static fd_set  fdSet;
-        static timeval timeout;
-
-        timeout = {delayMS / 1000, (delayMS % 1000) * 1000};
-        FD_ZERO(&fdSet);
-        FD_SET(pipeRead, &fdSet);
-
-        auto ret = select(pipeRead + 1, &fdSet, nullptr, nullptr, &timeout);
-        if (ret < 0) {
-            LOGV("failed to run select(..): %s\n", strerror(errno));
-            return ret;
-        }
-
-        if (ret == 0) {
-            return 0;
-        }
-    }
-    return read(pipeRead, &cmd, sizeof(cmd));
-}
-
 void handlePauseResume(int8_t cmd) {
     LOGV("appState=%d", cmd);
     std::unique_lock<std::mutex> lk(cc::cocosApp.mutex);
@@ -152,20 +130,19 @@ void glThreadEntry() {
     lk.unlock();
     cc::cocosApp.cond.notify_all();
 
-    int8_t cmd        = 0;
-    bool   runInLowRate = false;
+    int8_t cmd = 0;
     while (true) {
-
-        runInLowRate = !cc::cocosApp.animating || APP_CMD_PAUSE == cc::cocosApp.appState;
-
-        if (readCommandWithTimeout(cmd, runInLowRate ? 100 : 0) > 0) {
+        if (readCommand(cmd) > 0) {
             preExecCmd(cmd);
             cc::View::engineHandleCmd(cmd);
             postExecCmd(cmd);
         }
 
+        if (!cc::cocosApp.animating || APP_CMD_PAUSE == cc::cocosApp.appState) {
+            std::this_thread::yield();
+        }
 
-        if (game) {
+        if (game && cc::cocosApp.animating) {
             // Handle java events send by UI thread. Input events are handled here too.
             cc::JniHelper::callStaticVoidMethod("com.cocos.lib.CocosHelper",
                                                 "flushTasksOnGameThread");


### PR DESCRIPTION
This reverts commit 1191c1cf4e88af80dcc31a44ccb952b2e07362d4.

which will cause fault display when app create prefeb in background

* https://github.com/cocos-creator/3d-tasks/issues/10768
