### PR TITLE
m1 deferred rendering issue: fbf & write to same tex not fully support

### DIFF
--- a/cocos/renderer/gfx-metal/MTLUtils.mm
+++ b/cocos/renderer/gfx-metal/MTLUtils.mm
@@ -911,7 +911,7 @@ bool mu::isImageBlockSupported() {
     if(!mu::isFramebufferFetchSupported()) {
         return false;
     }
-#if (CC_PLATFORM == CC_PLATFORM_MAC_IOS) || TARGET_CPU_ARM64
+#if (CC_PLATFORM == CC_PLATFORM_MAC_IOS) //|| TARGET_CPU_ARM64
     return true;
 #else
     return false;
@@ -919,7 +919,7 @@ bool mu::isImageBlockSupported() {
 }
 
 bool mu::isFramebufferFetchSupported() {
-#if (CC_PLATFORM == CC_PLATFORM_MAC_IOS) || TARGET_CPU_ARM64
+#if (CC_PLATFORM == CC_PLATFORM_MAC_IOS) //|| TARGET_CPU_ARM64
     return true;
 #else
     return false;


### PR DESCRIPTION
对于fbf： 没事了里边input参数声明[color[n]]就可以了；
对于read&write同一个texture: 需要spirv编译的时候加入一些配置触发声明为texture<read_write>,也是可行的；

对于fbf+同时读写，ios跑起来并没有问题，m1下出现了闪烁，看效果像是是某些tile读写并没有完全按照shader顺序先读后写，现阶段所有资源都没有采用MTLHeap所以不需要加资源fence。
<img width="963" alt="Screen Shot 2022-01-14 at 9 42 41 AM" src="https://user-images.githubusercontent.com/18626925/149437254-3f56da37-4d0b-4980-9c6f-93a51ae15cbf.png">

