### PR TITLE
Optimising the initialisation timing of download tasks.

### DIFF
--- a/cocos/platform/android/java/src/org/cocos2dx/lib/Cocos2dxDownloader.java
+++ b/cocos/platform/android/java/src/org/cocos2dx/lib/Cocos2dxDownloader.java
@@ -179,6 +179,17 @@ public class Cocos2dxDownloader {
 
                     final Request request = builder.build();
                     task = downloader._httpClient.newCall(request);
+                    if (null == task) {
+                        final String errStr = "Can't create DownloadTask for " + url;
+                        Cocos2dxHelper.runOnGLThread(new Runnable() {
+                            @Override
+                            public void run() {
+                                downloader.nativeOnFinish(downloader._id, id, 0, errStr, null);
+                            }
+                        });
+                    } else {
+                        downloader._taskMap.put(id, task);
+                    }                    
                     task.enqueue(new Callback() {
                         @Override
                         public void onFailure(Call call, IOException e) {
@@ -289,18 +300,6 @@ public class Cocos2dxDownloader {
                         }
                     });
                 } while (false);
-
-                if (null == task) {
-                    final String errStr = "Can't create DownloadTask for " + url;
-                    Cocos2dxHelper.runOnGLThread(new Runnable() {
-                        @Override
-                        public void run() {
-                            downloader.nativeOnFinish(downloader._id, id, 0, errStr, null);
-                        }
-                    });
-                } else {
-                    downloader._taskMap.put(id, task);
-                }
             }
         };
         downloader.enqueueTask(taskRunnable);


### PR DESCRIPTION
alway check null value before use it, and this will fix some issue like no response return to business code when downloading a file.