### PR TITLE
implement syncCameraEditor  for editor's logic & remove unneed code

### DIFF
--- a/cocos/core/data/Object.cpp
+++ b/cocos/core/data/Object.cpp
@@ -51,10 +51,6 @@ void CCObject::deferredDestroy() {
     } else {
         objectsToDestroy.erase(objectsToDestroy.begin(), objectsToDestroy.begin() + deleteCount);
     }
-
-    //cjh TODO:    if (EDITOR) {
-    //        deferredDestroyTimer = null;
-    //    }
 }
 
 CCObject::CCObject(std::string name /* = ""*/)
@@ -73,23 +69,8 @@ bool CCObject::destroy() {
     addRef();
     objectsToDestroy.emplace_back(this);
 
-    //cjh TODO:   if (EDITOR && deferredDestroyTimer === null && legacyCC.engine && !legacyCC.engine._isUpdating) {
-    //        // auto destroy immediate in edit mode
-    //        // @ts-expect-error no function
-    //        deferredDestroyTimer = setImmediate(CCObject._deferredDestroy);
-    //    }
+    //NOTE: EDITOR's deferredDestroyTimer trigger from ts
     return true;
-}
-
-void CCObject::destruct() {
-    //cjh TODO: it seems that this function doesn't need to be implemented in c++
-    //    const ctor: any = this.constructor;
-    //    let destruct = ctor.__destruct__;
-    //    if (!destruct) {
-    //        destruct = compileDestruct(this, ctor);
-    //        js.value(ctor, '__destruct__', destruct, true);
-    //    }
-    //    destruct(this);
 }
 
 void CCObject::destroyImmediate() {
@@ -100,9 +81,7 @@ void CCObject::destroyImmediate() {
 
     onPreDestroy();
 
-    //cjh TODO:    if (!EDITOR || legacyCC.GAME_VIEW) {
-    destruct();
-    //    }
+    // NOTE: native has been use smart pointer, unneed to call TS's destruct logic
 
     _objFlags |= Flags::DESTROYED;
 }

--- a/cocos/core/data/Object.cpp
+++ b/cocos/core/data/Object.cpp
@@ -81,7 +81,7 @@ void CCObject::destroyImmediate() {
 
     onPreDestroy();
 
-    // NOTE: native has been use smart pointer, unneed to call TS's destruct logic
+    // NOTE: native has been use smart pointer, not needed to implement 'destruct' interface, remove 'destruct' reference code
 
     _objFlags |= Flags::DESTROYED;
 }

--- a/cocos/core/data/Object.h
+++ b/cocos/core/data/Object.h
@@ -218,7 +218,6 @@ public:
      *       }
      *
      */
-    void destruct();
 
     void destroyImmediate();
 

--- a/cocos/scene/Camera.cpp
+++ b/cocos/scene/Camera.cpp
@@ -136,15 +136,14 @@ void Camera::setFixedSize(uint32_t width, uint32_t height) {
 
 // Editor specific gizmo camera logic
 void Camera::syncCameraEditor(const Camera &camera) {
-    // TODO(xwx): EDITOR not implemented
-    // if (EDITOR) {
-    //     this.position     = camera.position;
-    //     this.forward      = camera.forward;
-    //     this._matView     = camera.matView;
-    //     this._matProj     = camera.matProj;
-    //     this._matProjInv  = camera.matProjInv;
-    //     this._matViewProj = camera.matViewProj;
-    // }
+#ifdef CC_EDITOR
+    this->_position    = camera._position;
+    this->_forward     = camera._forward;
+    this->_matView     = camera._matView;
+    this->_matProj     = camera._matProj;
+    this->_matProjInv  = camera._matProjInv;
+    this->_matViewProj = camera._matViewProj;
+#endif
 }
 
 void Camera::update(bool forceUpdate /*false*/) {


### PR DESCRIPTION
deferredDestroyTimer 由ts 实现并由 ts 调用，故删除native层不要注释
destruct ：ts的逻辑是解除引用，native层已通过智能指针实现生命周期管理，ts 对应的 destruct 是不必要的，故该接口删除