### PR TITLE
vk: fix android 12 crash

### DIFF
--- a/cocos/renderer/gfx-vulkan/VKCommands.cpp
+++ b/cocos/renderer/gfx-vulkan/VKCommands.cpp
@@ -166,15 +166,15 @@ void cmdFuncCCVKCreateTexture(CCVKDevice *device, CCVKGPUTexture *gpuTexture) {
     };
 
     if (gpuTexture->swapchain) {
-        uint32_t backBufferCount = device->gpuDevice()->backBufferCount;
+        size_t backBufferCount = gpuTexture->swapchain->swapchainImages.size();
         gpuTexture->swapchainVkImages.resize(backBufferCount);
         if (GFX_FORMAT_INFOS[toNumber(gpuTexture->format)].hasDepth) {
             gpuTexture->swapchainVmaAllocations.resize(backBufferCount);
-            for (uint32_t i = 0; i < backBufferCount; ++i) {
+            for (size_t i = 0; i < backBufferCount; ++i) {
                 createFn(&gpuTexture->swapchainVkImages[i], &gpuTexture->swapchainVmaAllocations[i]);
             }
         } else {
-            for (uint32_t i = 0; i < backBufferCount; ++i) {
+            for (size_t i = 0; i < backBufferCount; ++i) {
                 gpuTexture->swapchainVkImages[i] = gpuTexture->swapchain->swapchainImages[i];
             }
         }
@@ -202,9 +202,9 @@ void cmdFuncCCVKCreateTextureView(CCVKDevice *device, CCVKGPUTextureView *gpuTex
     };
 
     if (gpuTextureView->gpuTexture->swapchain) {
-        uint32_t backBufferCount = device->gpuDevice()->backBufferCount;
+        size_t backBufferCount = gpuTextureView->gpuTexture->swapchain->swapchainImages.size();
         gpuTextureView->swapchainVkImageViews.resize(backBufferCount);
-        for (uint32_t i = 0; i < backBufferCount; ++i) {
+        for (size_t i = 0; i < backBufferCount; ++i) {
             createFn(gpuTextureView->gpuTexture->swapchainVkImages[i], &gpuTextureView->swapchainVkImageViews[i]);
         }
     } else if (gpuTextureView->gpuTexture->vkImage) {

--- a/cocos/renderer/gfx-vulkan/VKDevice.cpp
+++ b/cocos/renderer/gfx-vulkan/VKDevice.cpp
@@ -683,6 +683,18 @@ void CCVKDevice::waitAllFences() {
     }
 }
 
+void CCVKDevice::updateBackBufferCount(uint32_t backBufferCount) {
+    if (backBufferCount <= _gpuDevice->backBufferCount) return;
+    for (uint32_t i = _gpuDevice->backBufferCount; i < backBufferCount; i++) {
+        _gpuFencePools.push_back(CC_NEW(CCVKGPUFencePool(_gpuDevice)));
+        _gpuRecycleBins.push_back(CC_NEW(CCVKGPURecycleBin(_gpuDevice)));
+        _gpuStagingBufferPools.push_back(CC_NEW(CCVKGPUStagingBufferPool(_gpuDevice)));
+    }
+    _gpuBufferHub->updateBackBufferCount(backBufferCount);
+    _gpuDescriptorSetHub->updateBackBufferCount(backBufferCount);
+    _gpuDevice->backBufferCount = backBufferCount;
+}
+
 CommandBuffer *CCVKDevice::createCommandBuffer(const CommandBufferInfo & /*info*/, bool /*hasAgent*/) {
     return CC_NEW(CCVKCommandBuffer);
 }

--- a/cocos/renderer/gfx-vulkan/VKDevice.h
+++ b/cocos/renderer/gfx-vulkan/VKDevice.h
@@ -98,6 +98,8 @@ public:
     CCVKGPUStagingBufferPool *gpuStagingBufferPool();
     void                      waitAllFences();
 
+    void updateBackBufferCount(uint32_t backBufferCount);
+
 protected:
     static CCVKDevice *instance;
 

--- a/cocos/renderer/gfx-vulkan/VKGPUObjects.h
+++ b/cocos/renderer/gfx-vulkan/VKGPUObjects.h
@@ -867,6 +867,10 @@ public:
         sets.clear();
     }
 
+    void updateBackBufferCount(uint32_t backBufferCount) {
+        _setsToBeUpdated.resize(backBufferCount);
+    }
+
 private:
     void update(const CCVKGPUDescriptorSet *gpuDescriptorSet) {
         const CCVKGPUDescriptorSet::Instance &instance = gpuDescriptorSet->instances[_device->curBackBufferIndex];
@@ -1331,6 +1335,10 @@ public:
                 _buffersToBeUpdated[i].erase(gpuBuffer);
             }
         }
+    }
+
+    void updateBackBufferCount(uint32_t backBufferCount) {
+        _buffersToBeUpdated.resize(backBufferCount);
     }
 
     void flush(CCVKGPUTransportHub *transportHub);

--- a/cocos/renderer/gfx-vulkan/VKSwapchain.cpp
+++ b/cocos/renderer/gfx-vulkan/VKSwapchain.cpp
@@ -150,11 +150,7 @@ void CCVKSwapchain::doInit(const SwapchainInfo &info) {
 #endif
 
     // Determine the number of images
-    // for now we assume triple buffer is universal
-    uint32_t desiredNumberOfSwapchainImages = gpuDevice->backBufferCount;
-    CCASSERT(desiredNumberOfSwapchainImages <= surfaceCapabilities.maxImageCount &&
-                 desiredNumberOfSwapchainImages >= surfaceCapabilities.minImageCount,
-             "Swapchain image count assumption broken");
+    uint32_t desiredNumberOfSwapchainImages = std::max(gpuDevice->backBufferCount, surfaceCapabilities.minImageCount);
 
     VkExtent2D                    imageExtent  = {1U, 1U};
     VkSurfaceTransformFlagBitsKHR preTransform = VK_SURFACE_TRANSFORM_IDENTITY_BIT_KHR;
@@ -302,10 +298,9 @@ bool CCVKSwapchain::checkSwapchainStatus(uint32_t width, uint32_t height) {
 
     uint32_t imageCount;
     VK_CHECK(vkGetSwapchainImagesKHR(gpuDevice->vkDevice, _gpuSwapchain->vkSwapchain, &imageCount, nullptr));
+    CCVKDevice::getInstance()->updateBackBufferCount(imageCount);
     _gpuSwapchain->swapchainImages.resize(imageCount);
     VK_CHECK(vkGetSwapchainImagesKHR(gpuDevice->vkDevice, _gpuSwapchain->vkSwapchain, &imageCount, _gpuSwapchain->swapchainImages.data()));
-
-    CCASSERT(imageCount == _gpuSwapchain->createInfo.minImageCount, "swapchain image count assumption is broken");
 
     // should skip size check, since the old swapchain has already been destroyed
     static_cast<CCVKTexture *>(_colorTexture)->_info.width        = 1;


### PR DESCRIPTION
Re: https://github.com/cocos-creator/3d-tasks/issues/11003

The Vulkan driver shipped in Android 12 breaks our assumption about swapchain image count (the actual count equals the `minImageCount` parameter). This PR removes this assumption and allows dynamic resizing after device initialized but before any buffers are created.