### PR TITLE
supply a default context when surface destroyed 

### DIFF
--- a/cocos/renderer/gfx-gles2/GLES2Swapchain.cpp
+++ b/cocos/renderer/gfx-gles2/GLES2Swapchain.cpp
@@ -124,7 +124,7 @@ void GLES2Swapchain::doDestroySurface() {
         auto* context = GLES2Device::getInstance()->context();
         eglDestroySurface(context->eglDisplay, _gpuSwapchain->eglSurface);
         _gpuSwapchain->eglSurface = EGL_NO_SURFACE;
-        context->bindContext(false);
+        context->bindContext(true);
     }
 }
 

--- a/cocos/renderer/gfx-gles3/GLES3Swapchain.cpp
+++ b/cocos/renderer/gfx-gles3/GLES3Swapchain.cpp
@@ -124,7 +124,7 @@ void GLES3Swapchain::doDestroySurface() {
         auto* context = GLES3Device::getInstance()->context();
         eglDestroySurface(context->eglDisplay, _gpuSwapchain->eglSurface);
         _gpuSwapchain->eglSurface = EGL_NO_SURFACE;
-        context->bindContext(false);
+        context->bindContext(true);
     }
 }
 


### PR DESCRIPTION
* https://github.com/cocos-creator/3d-tasks/issues/10945

Description:

Restart with minimize the application, create shader failed because context is null, thus the application will crash for win32.