### PR TITLE
fix simulator SimulatorWin::windowProc setting fail on window x64.

### DIFF
--- a/tools/simulator/frameworks/runtime-src/proj.win32/SimulatorWin.cpp
+++ b/tools/simulator/frameworks/runtime-src/proj.win32/SimulatorWin.cpp
@@ -513,7 +513,7 @@ int SimulatorWin::run()
     // prepare
     _project.dump();
 
-    g_oldWindowProc = (WNDPROC)SetWindowLong(_hwnd, GWLP_WNDPROC, (LONG)SimulatorWin::windowProc);
+    g_oldWindowProc = (WNDPROC)SetWindowLongPtr(_hwnd, GWLP_WNDPROC, (LONG_PTR)SimulatorWin::windowProc);
 
     // update window title
     updateWindowTitle();


### PR DESCRIPTION
https://docs.microsoft.com/en-us/windows/win32/api/winuser/nf-winuser-setwindowlongptra