### PR TITLE
Fix loop audio would stop for ios system 

### DIFF
--- a/cocos/audio/apple/AudioMacros.h
+++ b/cocos/audio/apple/AudioMacros.h
@@ -26,7 +26,7 @@
 
 #pragma once
 
-#define QUEUEBUFFER_NUM       (3)
+#define QUEUEBUFFER_NUM       (4)
 #define QUEUEBUFFER_TIME_STEP (0.05f)
 
 #define QUOTEME_(x) #x

--- a/cocos/audio/apple/AudioPlayer.mm
+++ b/cocos/audio/apple/AudioPlayer.mm
@@ -244,7 +244,12 @@ void AudioPlayer::rotateBufferThread(int offsetFrame) {
 
         while (!_isDestroyed) {
             alGetSourcei(_alSource, AL_SOURCE_STATE, &sourceState);
-            if (sourceState == AL_PLAYING) {
+            /* On IOS, audio state will lie, when the system is not fully foreground,
+             * openAl will process the buffer in queue, but our condition cannot make sure that the audio
+             * is playing as it's too short. Interesting IOS system.
+             * Solution is to load buffer even if it's paused, just make sure that there's no bufferProcessed in 
+             */
+            if (sourceState == AL_PLAYING || sourceState == AL_PAUSED) {
                 alGetSourcei(_alSource, AL_BUFFERS_PROCESSED, &bufferProcessed);
                 while (bufferProcessed > 0) {
                     bufferProcessed--;


### PR DESCRIPTION
* IOS system has an uncertain state between foreground and background, and our condition sometimes miss the point to load buffers.
* Queue for 3 buffers might be too short to live, use 4 or even more instead.
* Issue could be solved: 
* https://github.com/cocos2d/cocos2d-x/issues/19480, 
* https://github.com/cocos-creator/3d-tasks/issues/11135